### PR TITLE
Add forgotten fixture setter

### DIFF
--- a/src/DataFixtures/FixtureBuilder.php
+++ b/src/DataFixtures/FixtureBuilder.php
@@ -129,6 +129,7 @@ class FixtureBuilder
         $conference->setCfpUrl($description['cfpUrl']);
         $conference->setStartAt($description['startAt']);
         $conference->setEndAt($description['endAt']);
+        $conference->setCfpEndAt($description['endAt']);
 
         foreach ($description['participations'] as $participation) {
             $conference->addParticipation($participation);


### PR DESCRIPTION
I forgot a setter in the fixtures leading to `null` in the cfpEndAt column in the nextConference list view