### PR TITLE
Fix minor issues in fixtures and talk list view

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -1,3 +1,7 @@
 #talk_submits [name$="[talk][autocomplete]"] + .select2 {
     display: none;
 }
+
+td.text > ul {
+    margin-bottom: 0;
+}

--- a/src/DataFixtures/FixtureBuilder.php
+++ b/src/DataFixtures/FixtureBuilder.php
@@ -129,7 +129,7 @@ class FixtureBuilder
         $conference->setCfpUrl($description['cfpUrl']);
         $conference->setStartAt($description['startAt']);
         $conference->setEndAt($description['endAt']);
-        $conference->setCfpEndAt($description['endAt']);
+        $conference->setCfpEndAt($description['cfpEndAt']);
 
         foreach ($description['participations'] as $participation) {
             $conference->addParticipation($participation);


### PR DESCRIPTION
This addresses two mnior issues :

-  margin bottom on `ul` in talk list view was not great
-  cfpEndAt was set to endAt in the default fixtures