### PR TITLE
PHPStan bug with console

### DIFF
--- a/config/packages/phpstan/parameters.yaml
+++ b/config/packages/phpstan/parameters.yaml
@@ -1,0 +1,2 @@
+parameters:
+    container.dumper.inline_class_loader: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,7 +12,8 @@ parameters:
     inferPrivatePropertyTypeFromConstructor: true
 
     symfony:
-        container_xml_path: 'var/cache/dev/App_KernelDevDebugContainer.xml'
+        container_xml_path: var/cache/dev/App_KernelDevDebugContainer.xml
+        console_application_loader: var/phpstan-utilities/console-application.php
 
     doctrine:
         objectManagerLoader: var/phpstan-utilities/object-manager.php

--- a/var/phpstan-utilities/console-application.php
+++ b/var/phpstan-utilities/console-application.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * This file is part of the Starfleet Project.
+ *
+ * (c) Starfleet <msantostefano@jolicode.com>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code.
+ */
+
+require __DIR__.'../../../config/bootstrap.php';
+$kernel = new \App\Kernel('phpstan', true);
+
+return new \Symfony\Bundle\FrameworkBundle\Console\Application($kernel);


### PR DESCRIPTION
This is not meant to be merged, this is just to show a bug.

This PR shows a bug with the `console-application.php` file, resulting in this error with the vendors :

![PHPStan](https://user-images.githubusercontent.com/71645693/102792869-5c2e3c00-43a9-11eb-95b6-2a710969abb0.png)

I'm not sure whether this comes from us or from PHPStan.