### PR TITLE
Fix rename migration

### DIFF
--- a/migrations/Version20210112170750.php
+++ b/migrations/Version20210112170750.php
@@ -21,10 +21,14 @@ final class Version20210112170750 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->addSql('ALTER TABLE excluded_tag RENAME TO conference_filter');
+        $this->addSql('DROP SEQUENCE excluded_tag_id_seq CASCADE');
+        $this->addSql('CREATE SEQUENCE conference_filter_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
     }
 
     public function down(Schema $schema): void
     {
         $this->addSql('ALTER TABLE conference_filter RENAME TO excluded_tag');
+        $this->addSql('DROP SEQUENCE conference_filter_id_seq CASCADE');
+        $this->addSql('CREATE SEQUENCE excluded_tag_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
     }
 }


### PR DESCRIPTION
When I renamed the ExcludedTag entity to ConferenceFilter, I forgot to add the sequence to the migration, so this fixes it