### PR TITLE
Fix Participation admin bug

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -9,3 +9,7 @@ td.text > ul {
 td.country {
     text-align: center;
 }
+
+.form-group .checkbox-switch label {
+    margin: 0;
+}

--- a/config/packages/easy_admin.yaml
+++ b/config/packages/easy_admin.yaml
@@ -8,7 +8,7 @@ easy_admin:
         menu:
             - { entity: 'NextConference', label: 'Next Conferences', icon: 'forward', default: true }
             - { entity: 'PassedConference', label: 'Passed Conferences', icon: 'backward' }
-            - { entity: 'ExcludedConferences', label: 'Excluded Conferences', icon: 'times' }
+            - { entity: 'ExcludedConference', label: 'Excluded Conferences', icon: 'times' }
             - { entity: 'Participation', label: 'Participations', icon: 'id-badge' }
             - { entity: 'Talk', label: 'Talks', icon: 'file-text-o' }
             - { entity: 'ConferenceFilter', label: 'Ignored Subjects', icon: 'times' }

--- a/config/packages/easy_admin/conference.yaml
+++ b/config/packages/easy_admin/conference.yaml
@@ -15,9 +15,24 @@ easy_admin:
                     - { property: 'endAt', type: 'date' }
                     - { property: 'source', type: 'text' }
                     - { property: 'tags', type: 'array' }
+            show:
+                fields: &conferenceShow
+                    1: { property: name, type: text }
+                    2: { property: city, type: text }
+                    3: { property: country, type: country }
+                    4: { property: source, type: text }
+                    5: { property: description, type: text}
+                    6: { property: startAt, type: date }
+                    7: { property: endAt, type: date }
+                    8: { property: cfpUrl, type: url }
+                    9: { property: cfpEndAt, type: date }
+                    10: { property: siteUrl, type: url }
+                    11: { property: articleUrl, type: url }
+                    12: { property: submits, label: 'Submissions', type: embedded_list, css_class: "d-block mx-auto" }
+                    13: { property: participations, type: embedded_list, css_class: "d-block mx-auto" }
         NextConference:
             class: App\Entity\Conference
-            disabled_actions: ['show', 'delete']
+            disabled_actions: ['delete']
             list:
                 filters: ['name', 'city', 'country', 'startAt', 'tags', 'source']
                 actions:
@@ -48,7 +63,10 @@ easy_admin:
                     - { property: 'cfpEndAt', type: 'date', 'type_options': { 'widget': 'single_text' } }
                     - { type: 'group', columns: 4, icon: 'cubes', label: 'Metadata' }
                     - { property: 'articleUrl', type: 'url' }
-        ExcludedConferences:
+            show:
+                fields:
+                    <<: *conferenceShow
+        ExcludedConference:
             class: App\Entity\Conference
             disabled_actions: ['delete']
             list:
@@ -64,3 +82,6 @@ easy_admin:
                     - { property: 'cfpEndAt', type: 'date' }
                     - { property: 'source', type: 'text' }
                     - { property: 'tags', type: 'array' }
+            show:
+                fields:
+                    <<: *conferenceShow

--- a/config/packages/easy_admin/participation.yaml
+++ b/config/packages/easy_admin/participation.yaml
@@ -9,7 +9,7 @@ easy_admin:
                 filters: ['conference', 'participant']
                 item_permission: ['PARTICIPATION_SHOW']
                 fields:
-                    - { property: 'conference' }
+                    - { property: 'conference', template: 'easy_admin/Participation/conference.html.twig' }
                     - { property: 'participant' }
                     - { property: 'asSpeaker' }
                     - { property: 'needTransport' }

--- a/src/Entity/Conference.php
+++ b/src/Entity/Conference.php
@@ -391,4 +391,17 @@ class Conference
     {
         return $this->tags;
     }
+
+    public function guessConferenceType(): string
+    {
+        if ($this->excluded) {
+            return 'ExcludedConference';
+        }
+
+        if ($this->endAt < new \DateTime()) {
+            return 'PassedConference';
+        }
+
+        return 'NextConference';
+    }
 }

--- a/templates/easy_admin/Participation/conference.html.twig
+++ b/templates/easy_admin/Participation/conference.html.twig
@@ -1,0 +1,8 @@
+<a href="{{ path('easyadmin', {
+        'entity': item.conference.guessConferenceType,
+        'id': link_parameters.id,
+        'action': 'show'
+        })
+    }}">
+    {{ value }}
+</a>


### PR DESCRIPTION
We currently have a bug in the admin if we try to access a conference that has participations. This is because the show action is currently not handled, so we're adding it.

I also allowed the show action for all conferences. It was not the case before but this might have been on purpose.