### PR TITLE
Handle null country

### DIFF
--- a/templates/conferences/list.html.twig
+++ b/templates/conferences/list.html.twig
@@ -18,7 +18,7 @@
                             <h6 class="card-subtitle mb-2 text-muted font-weight-normal">
                             {% if conference.online %}
                                 Online <img class="country-flag" alt="Online Icon" src="{{ asset('build/images/online.svg') }}">
-                            {% else %}
+                            {% elseif conference.country %}
                                 {{ conference.city }} <img class="country-flag" alt="Country Flag" src="/bundles/easyadmin/images/flags/{{ conference.country|upper }}.png">
                             {% endif %}
                             </h6>

--- a/templates/easy_admin/Conference/country.html.twig
+++ b/templates/easy_admin/Conference/country.html.twig
@@ -1,5 +1,5 @@
 {% if item.online %}
     <img class="country-flag" alt="Online image" title="Online" src="{{ asset('build/images/online.svg') }}">
-{% else %}
+{% elseif value %}
     <img class="country-flag" alt="{{ country_name }} flag" title="{{ country_name }}" src="/bundles/easyadmin/images/flags/{{ value }}.png">
 {% endif %}


### PR DESCRIPTION
If a conference country was set to null for some reason (like if someone manually added it) the flag would only show a broken img link, so in this case we just want to show nothing