### PR TITLE
Improve map feature when few coordinates are provided

### DIFF
--- a/src/Controller/ConferenceController.php
+++ b/src/Controller/ConferenceController.php
@@ -78,7 +78,7 @@ class ConferenceController extends AbstractController
             } else {
                 $liveConferences[] = $conference;
             }
-            if (!$conference->isOnline() && null !== $conference->getCoordinates()) {
+            if (!$conference->isOnline() && null !== $conference->getCoordinates() && !\in_array($conference->getCoordinates(), $conferenceCoordinates)) {
                 $conferenceCoordinates[] = $conference->getCoordinates();
             }
         }

--- a/src/Twig/MapboxUrlEncoder.php
+++ b/src/Twig/MapboxUrlEncoder.php
@@ -37,6 +37,12 @@ class MapboxUrlEncoder extends AbstractExtension
             return null;
         }
 
+        $zoom = 'auto';
+
+        if (1 === \count($coordinates)) {
+            $zoom = "{$coordinates[0][0]}, {$coordinates[0][1]}, 5";
+        }
+
         $apiConfig = [
             'type' => 'FeatureCollection',
             'features' => [
@@ -51,6 +57,6 @@ class MapboxUrlEncoder extends AbstractExtension
         $encodeApiConfig = urlencode(json_encode($apiConfig));
         $encodeApiToken = http_build_query(['access_token' => $this->apiToken]);
 
-        return sprintf('https://api.mapbox.com/styles/v1/mapbox/streets-v11/static/geojson(%s)/auto/1000x600?%s', $encodeApiConfig, $encodeApiToken);
+        return sprintf('https://api.mapbox.com/styles/v1/mapbox/streets-v11/static/geojson(%s)/%s/1000x600?%s', $encodeApiConfig, $zoom, $encodeApiToken);
     }
 }

--- a/templates/map.html.twig
+++ b/templates/map.html.twig
@@ -1,6 +1,8 @@
 {% set url = mapboxEncode(conferenceCoordinates) %}
 
-{% if url == null %}
+{% if conferenceCoordinates|length == 0 %}
+    <div class="text-muted">You don't have any conference to show on the map. This may be because they are all online.</div>
+{% elseif url == null %}
     <div class="alert alert-warning">It seems you forgot to provide an access token to enable the map feature.</div>
 {% else %}
     <img src="{{ url }}" alt="Map of where we attended conferences" class="w-100 mw-100">


### PR DESCRIPTION
This helps with cases where we have few coordinates in the database. Currently, if we have none (or if all conferences were online) we display a broken link. If we have only one conference to show on the map, it will show the street.

Now, we have a warning if we have no conferences to display, and if we have only one conference to display it adjusts the zoom.