### PR TITLE
Uppercase country code in the DB

### DIFF
--- a/migrations/Version20210223150819.php
+++ b/migrations/Version20210223150819.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Starfleet Project.
+ *
+ * (c) Starfleet <msantostefano@jolicode.com>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20210223150819 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE conference SET country = UPPER(country)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('UPDATE conference SET country = LOWER(country)');
+    }
+}

--- a/src/Fetcher/LocationGuesser.php
+++ b/src/Fetcher/LocationGuesser.php
@@ -49,7 +49,7 @@ class LocationGuesser
             return null;
         }
 
-        return $results->first()->getCountry()->getCode();
+        return strtoupper($results->first()->getCountry()->getCode());
     }
 
     /** @return array<float> */


### PR DESCRIPTION
If we don't uppercase the country code in database this leads to a bug with symfony countryType not being able to recognize the country, so we should uppercase the country code in the database