### PR TITLE
Add tests for ConferenceHarvester

### DIFF
--- a/tests/Conference/ConferenceHarvesterTest.php
+++ b/tests/Conference/ConferenceHarvesterTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the Starfleet Project.
+ *
+ * (c) Starfleet <msantostefano@jolicode.com>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace App\Tests\Conference;
+
+use App\Conferences\ConferencesHarvester;
+use App\Entity\Conference;
+use App\Entity\ConferenceFilter;
+use App\Entity\FetcherConfiguration;
+use App\Fetcher\TululaFetcher;
+use App\Repository\ConferenceFilterRepository;
+use App\Repository\ConferenceRepository;
+use App\Repository\FetcherConfigurationRepository;
+use Doctrine\ORM\EntityManager;
+use Prophecy\Argument;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class ConferenceHarvesterTest extends KernelTestCase
+{
+    /**
+     * @dataProvider provideFetcherResponses
+     */
+    public function testFetch(int $expectedUpdated, int $expectedAdded, string $name, bool $isActive, Conference $conference, ?Conference $existingConference)
+    {
+        $results = $this->createHarvester($name, $isActive, $conference, $existingConference)->harvest();
+
+        self::assertSame($expectedUpdated, $results['updatedConferencesCount']);
+        self::assertSame($expectedAdded, $results['newConferencesCount']);
+    }
+
+    public function provideFetcherResponses()
+    {
+        $testConference = new Conference();
+        $testConference
+            ->setName('TestConference')
+            ->setStartAt(new \DateTime());
+
+        $differentTestConference = new Conference();
+        $differentTestConference
+            ->setName('OtherTestConference')
+            ->setStartAt(new \DateTime('+1 year'));
+
+        $ignoredTestConference = new Conference();
+        $ignoredTestConference
+            ->setName('Java Conference');
+
+        yield 'test fetchers add new conference' => [
+            'expectedUpdatedConferences' => 0,
+            'expectedAddedConferences' => 1,
+            'name' => TululaFetcher::class,
+            'isActive' => true,
+            'conference' => $testConference,
+            'existingConference' => null,
+        ];
+
+        yield 'test fetchers update existing conference' => [
+            'expectedUpdatedConferences' => 1,
+            'expectedAddedConferences' => 0,
+            'name' => TululaFetcher::class,
+            'isActive' => true,
+            'conference' => $testConference,
+            'existingConference' => $differentTestConference,
+        ];
+
+        yield 'test inactive fetcher' => [
+            'expectedUpdatedConferences' => 0,
+            'expectedAddedConferences' => 0,
+            'name' => TululaFetcher::class,
+            'isActive' => false,
+            'conference' => $testConference,
+            'existingConference' => null,
+        ];
+
+        yield 'conference should be ignored' => [
+            'expectedUpdatedConferences' => 0,
+            'expectedAddedConferences' => 0,
+            'name' => TululaFetcher::class,
+            'isActive' => true,
+            'conference' => $ignoredTestConference,
+            'existingConference' => null,
+        ];
+    }
+
+    private function createHarvester(string $name, bool $isActive, Conference $conference, ?Conference $existingConference)
+    {
+        $fetcherProphecy = $this->prophesize($name);
+        $fetcherProphecy
+            ->fetch([])
+            ->willYield([$conference]);
+
+        $fetcherConfigurationRepository = $this->prophesize(FetcherConfigurationRepository::class);
+        $fetcherConfigurationRepository
+            ->findOneOrCreate(Argument::type('string'))
+            ->willReturn($fetcherConfiguration = new FetcherConfiguration('Test'));
+        $fetcherConfiguration->setActive($isActive);
+
+        $conferenceFilterRepository = $this->prophesize(ConferenceFilterRepository::class);
+        $conferenceFilterRepository
+            ->findAll()
+            ->willReturn([$filter = new ConferenceFilter()]);
+        $filter->setName('java');
+
+        $conferenceRepository = $this->prophesize(ConferenceRepository::class);
+        $conferenceRepository
+            ->findExistingConference(Argument::type(Conference::class))
+            ->willReturn($existingConference);
+
+        $entityManager = $this->prophesize(EntityManager::class);
+        $entityManager
+            ->persist(Argument::type(Conference::class));
+        $entityManager
+            ->flush();
+
+        $harvester = new ConferencesHarvester(
+            [$fetcherProphecy->reveal()],
+            $fetcherConfigurationRepository->reveal(),
+            $conferenceFilterRepository->reveal(),
+            $conferenceRepository->reveal(),
+            $entityManager->reveal()
+        );
+
+        return $harvester;
+    }
+}


### PR DESCRIPTION
This adds tests for the ConferenceHarvester.

I also noticed 2 bugs that I fixed :

- If a fetcher wasn't active it would completely skip all remaining fetchers due to a return instead of continue
- `fnmmatch` wasn't working as intended and we weren't handling case issues for tags