### PR TITLE
Fix Slack links when cfp url is missing

### DIFF
--- a/src/Event/CfpEndingSoonEvent.php
+++ b/src/Event/CfpEndingSoonEvent.php
@@ -41,7 +41,11 @@ class CfpEndingSoonEvent extends Event
     {
         $cfpAttachment = SlackNotifier::ATTACHMENT;
         $template = '🔊  CFP for %s (%s) is closing %s';
-        $conferenceLink = sprintf('<%s|%s>', $this->conference->getCfpUrl(), $this->conference->getName());
+        if (null !== $this->conference->getSiteUrl()) {
+            $conferenceLink = sprintf('<%s|%s>', $this->conference->getSiteUrl(), $this->conference->getName());
+        } else {
+            $conferenceLink = $this->conference->getName();
+        }
         $countdown = 'in *'.$this->remainingDays.' day'.($this->remainingDays > 1 ? 's' : '').'* !';
 
         switch ($this->remainingDays) {
@@ -72,10 +76,12 @@ class CfpEndingSoonEvent extends Event
             $cfpAttachment['fields'][] = $talksField;
         }
 
-        $actionsField = SlackNotifier::SHORT_FIELD;
-        $actionsField['title'] = 'Submit a talk';
-        $actionsField['value'] = sprintf('<%s|%s>', $this->conference->getCfpUrl(), 'Go to the CFP  👉');
-        $cfpAttachment['fields'][] = $actionsField;
+        if (null !== $this->conference->getCfpUrl()) {
+            $actionsField = SlackNotifier::SHORT_FIELD;
+            $actionsField['title'] = 'Submit a talk';
+            $actionsField['value'] = sprintf('<%s|%s>', $this->conference->getCfpUrl(), 'Go to the CFP  👉');
+            $cfpAttachment['fields'][] = $actionsField;
+        }
 
         return $cfpAttachment;
     }


### PR DESCRIPTION
We previously had an issue with slack messages when a conference didn't have a cfp url as shown in https://github.com/jolicode/starfleet/issues/144 , so this fixes it.

I also changed the link in the main message to be the link to the conference url rather than the cfp because we had twice the cfp url but we never had the conference url. This could be reverted.