### PR TITLE
Allow adding a talk to multiple conferences

### DIFF
--- a/config/packages/easy_admin/talk.yaml
+++ b/config/packages/easy_admin/talk.yaml
@@ -23,7 +23,7 @@ easy_admin:
                     2: { property: 'title', type: 'text' }
                     3: { property: 'intro', type: 'textarea' }
                     4: { type: 'group', columns: 6, icon: 'send', label: 'Publication' }
-                    5: { property: 'conference', type: 'easyadmin_autocomplete', type_options: { mapped: false, class: App\Entity\Conference } }
+                    5: { property: 'conference', type: 'easyadmin_autocomplete', type_options: { mapped: false, class: App\Entity\Conference, multiple: true } }
             edit:
                 fields:
                     <<: *talkFields

--- a/src/Controller/Admin/AdminController.php
+++ b/src/Controller/Admin/AdminController.php
@@ -204,19 +204,21 @@ class AdminController extends EasyAdminController
 
     protected function persistTalkEntity(Talk $talk, Form $newForm): void
     {
-        $conference = $newForm->get('conference')->getData();
+        $conferences = $newForm->get('conference')->getData();
 
-        if ($conference instanceof Conference) {
-            $submit = new Submit();
-            $submit->setCreatedAt(new \DateTime());
-            $submit->setUpdatedAt(new \DateTime());
-            $submit->setSubmittedAt(new \DateTime());
-            $submit->setConference($conference);
-            $submit->setTalk($talk);
-            $submit->setStatus(Submit::STATUS_PENDING);
-            $submit->addUser($this->getUser());
+        foreach ($conferences as $conference) {
+            if ($conference instanceof Conference) {
+                $submit = new Submit();
+                $submit->setCreatedAt(new \DateTime());
+                $submit->setUpdatedAt(new \DateTime());
+                $submit->setSubmittedAt(new \DateTime());
+                $submit->setConference($conference);
+                $submit->setTalk($talk);
+                $submit->setStatus(Submit::STATUS_PENDING);
+                $submit->addUser($this->getUser());
 
-            $this->em->persist($submit);
+                $this->em->persist($submit);
+            }
         }
 
         $this->em->persist($talk);


### PR DESCRIPTION
Currently, we may add only one conference when we create a talk.

We should be able to create a submit for multiple conferences when we create a talk.