### PR TITLE
Group new talks in slack

### DIFF
--- a/config/packages/easy_admin/talk.yaml
+++ b/config/packages/easy_admin/talk.yaml
@@ -1,6 +1,7 @@
 easy_admin:
     entities:
         Talk:
+            controller: App\Controller\Admin\TalkController
             class: App\Entity\Talk
             list:
                 filters: ['title', 'intro', 'createdAt']

--- a/src/Controller/Admin/AdminController.php
+++ b/src/Controller/Admin/AdminController.php
@@ -14,11 +14,8 @@ namespace App\Controller\Admin;
 use AlterPHP\EasyAdminExtensionBundle\Controller\EasyAdminController;
 use App\Entity\Conference;
 use App\Entity\Participation;
-use App\Entity\Submit;
-use App\Entity\Talk;
 use App\Enum\Workflow\Transition\Participation as ParticipationTransition;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
-use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Workflow\Registry as WorkflowRegistry;
@@ -200,28 +197,5 @@ class AdminController extends EasyAdminController
             'action' => 'list',
             'entity' => $this->request->query->get('entity'),
         ]);
-    }
-
-    protected function persistTalkEntity(Talk $talk, Form $newForm): void
-    {
-        $conferences = $newForm->get('conference')->getData();
-
-        foreach ($conferences as $conference) {
-            if ($conference instanceof Conference) {
-                $submit = new Submit();
-                $submit->setCreatedAt(new \DateTime());
-                $submit->setUpdatedAt(new \DateTime());
-                $submit->setSubmittedAt(new \DateTime());
-                $submit->setConference($conference);
-                $submit->setTalk($talk);
-                $submit->setStatus(Submit::STATUS_PENDING);
-                $submit->addUser($this->getUser());
-
-                $this->em->persist($submit);
-            }
-        }
-
-        $this->em->persist($talk);
-        $this->em->flush();
     }
 }

--- a/src/Controller/Admin/TalkController.php
+++ b/src/Controller/Admin/TalkController.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Starfleet Project.
+ *
+ * (c) Starfleet <msantostefano@jolicode.com>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace App\Controller\Admin;
+
+use AlterPHP\EasyAdminExtensionBundle\Controller\EasyAdminController;
+use App\Entity\Conference;
+use App\Entity\Submit;
+use App\Entity\Talk;
+use App\Event\NewTalkSubmittedEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\Form;
+
+class TalkController extends EasyAdminController
+{
+    private EventDispatcherInterface $eventDispatcher;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    protected function persistTalkEntity(Talk $talk, Form $newForm): void
+    {
+        $conferences = $newForm->get('conference')->getData();
+
+        $newSubmits = [];
+
+        foreach ($conferences as $conference) {
+            if ($conference instanceof Conference) {
+                $submit = new Submit();
+                $submit->setCreatedAt(new \DateTime());
+                $submit->setUpdatedAt(new \DateTime());
+                $submit->setSubmittedAt(new \DateTime());
+                $submit->setConference($conference);
+                $submit->setTalk($talk);
+                $submit->setStatus(Submit::STATUS_PENDING);
+                $submit->addUser($this->getUser());
+
+                $this->em->persist($submit);
+                $newSubmits[] = $submit;
+            }
+        }
+
+        $this->eventDispatcher->dispatch(new NewTalkSubmittedEvent($talk, $newSubmits));
+
+        $this->em->persist($talk);
+        $this->em->flush();
+    }
+}

--- a/src/EventListener/DoctrineEventSubscriber.php
+++ b/src/EventListener/DoctrineEventSubscriber.php
@@ -15,7 +15,6 @@ use App\Entity\Conference;
 use App\Entity\Submit;
 use App\Event\NewConferenceEvent;
 use App\Event\NewConferencesEvent;
-use App\Event\NewTalkSubmittedEvent;
 use App\Event\SubmitStatusChangedEvent;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
@@ -62,10 +61,6 @@ class DoctrineEventSubscriber implements EventSubscriber
 
     public function postPersist(LifecycleEventArgs $args): void
     {
-        if ($args->getObject() instanceof Submit) {
-            $this->eventDispatcher->dispatch(new NewTalkSubmittedEvent($args->getObject()));
-        }
-
         if ($args->getObject() instanceof Conference) {
             $this->conferencesAdded[] = $args->getObject();
         }

--- a/src/EventListener/SlackNotifierEventListener.php
+++ b/src/EventListener/SlackNotifierEventListener.php
@@ -58,7 +58,7 @@ class SlackNotifierEventListener implements EventSubscriberInterface
         }
 
         $payload = SlackNotifier::EMPTY_PAYLOAD;
-        $payload['attachments'][] = $event->buildAttachment();
+        $payload['attachments'] = $event->buildAttachment();
         $this->slackNotifier->notify($payload);
     }
 


### PR DESCRIPTION
This adresses https://github.com/jolicode/starfleet/issues/124.

It also relies on https://github.com/jolicode/starfleet/pull/148 to work.

I started removing Doctrine Events and creating our own ones instead, this is a first step in this direction. I will open a new PR soon to fully remove Doctrine Events.

How messages now look like if a talk is submitted multiple times :
![talks](https://user-images.githubusercontent.com/71645693/110774711-651f0300-825e-11eb-8a7a-25f4a5bc124f.png)
