### PR TITLE
Allow user to add authors on new Talk

### DIFF
--- a/config/packages/easy_admin/talk.yaml
+++ b/config/packages/easy_admin/talk.yaml
@@ -18,15 +18,19 @@ easy_admin:
                     - { property: 'createdAt' }
                     - { property: 'updatedAt' }
                     - { property: submits, label: 'Submissions', type: embedded_list, type_options: { entity: Submit, filters: { 'entity.talk': 'form:parent.data.id' } } }
-            new:
+
+            edit:
                 fields: &talkFields
                     1: { type: 'group', columns: 6, icon: 'pencil', label: 'Talk' }
                     2: { property: 'title', type: 'text' }
                     3: { property: 'intro', type: 'textarea' }
-                    4: { type: 'group', columns: 6, icon: 'send', label: 'Publication' }
-                    5: { property: 'conference', type: 'easyadmin_autocomplete', type_options: { mapped: false, class: App\Entity\Conference, multiple: true } }
-            edit:
-                fields:
-                    <<: *talkFields
                     4: { type: 'group', columns: 6, icon: 'send', label: 'Submits' }
                     5: { property: submits, type: collection, type_options: { entry_type: App\Form\TalkSubmitType } }
+
+            new:
+                fields:
+                    <<: *talkFields
+                    4: { type: 'group', columns: 6, icon: 'send', label: 'Publication' }
+                    5: { property: 'conferences', type: 'easyadmin_autocomplete', type_options: { mapped: false, class: App\Entity\Conference, multiple: true } }
+                    6: { property: authors, type: App\Form\TalkUserType, type_options: { mapped: false, required: true } }
+

--- a/src/Controller/Admin/TalkController.php
+++ b/src/Controller/Admin/TalkController.php
@@ -30,8 +30,8 @@ class TalkController extends EasyAdminController
 
     protected function persistTalkEntity(Talk $talk, Form $newForm): void
     {
-        $conferences = $newForm->get('conference')->getData();
-
+        $conferences = $newForm->get('conferences')->getData();
+        $authors = $newForm->get('authors')->getData();
         $newSubmits = [];
 
         foreach ($conferences as $conference) {
@@ -43,7 +43,10 @@ class TalkController extends EasyAdminController
                 $submit->setConference($conference);
                 $submit->setTalk($talk);
                 $submit->setStatus(Submit::STATUS_PENDING);
-                $submit->addUser($this->getUser());
+
+                foreach ($authors['authors'] as $author) {
+                    $submit->addUser($author);
+                }
 
                 $this->em->persist($submit);
                 $newSubmits[] = $submit;

--- a/src/Form/TalkUserType.php
+++ b/src/Form/TalkUserType.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Starfleet Project.
+ *
+ * (c) Starfleet <msantostefano@jolicode.com>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace App\Form;
+
+use App\Entity\User;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminAutocompleteType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+class TalkUserType extends AbstractType
+{
+    private TokenStorageInterface $tokenStorage;
+
+    public function __construct(TokenStorageInterface $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('authors', EasyAdminAutocompleteType::class, [
+                'label' => false,
+                'class' => User::class,
+                'multiple' => true,
+                'data' => [$this->tokenStorage->getToken()->getUser()],
+            ]);
+    }
+}


### PR DESCRIPTION
Right now, if we want to create a new talk given by multiple users, we have to create it, and then edit it to add new users, which is not handy. Same if an admin or anyone else wants to create a talk that will not be given by him, he has to create it then edit it.

Now we may add as many authors as we want, with the default author being current user. I made the field required however, but maybe we want to allow creating a talk with no author at all.

This will look like this :
![talk](https://user-images.githubusercontent.com/71645693/110930047-ef339e00-8328-11eb-82b6-ebded13ef2ed.png)
