### PR TITLE
Show submits in menu

### DIFF
--- a/config/packages/easy_admin.yaml
+++ b/config/packages/easy_admin.yaml
@@ -14,6 +14,7 @@ easy_admin:
             - { entity: 'ConferenceFilter', label: 'Ignored Subjects', icon: 'times' }
             - { entity: 'User', label: 'Users', icon: 'users' }
             - { entity: 'Continent', label: 'Continents', icon: 'globe' }
+            - { entity: 'Submit', label: 'Submitted Talks', icon: 'check-circle' }
             - { label: 'Fetchers', route: 'fetcher_list', icon: 'bell' }
         assets:
             css:

--- a/config/packages/easy_admin/submit.yaml
+++ b/config/packages/easy_admin/submit.yaml
@@ -3,8 +3,13 @@ easy_admin:
         Submit:
             class: App\Entity\Submit
             disabled_actions: ['show']
+            edit:
+                role: SUBMIT_EDIT
+            delete:
+                role: SUBMIT_EDIT
             list:
                 filters: ['talk', 'conference', 'submittedAt', 'status', 'users']
+                role: ROLE_USER
                 fields:
                     - { property: 'talk' }
                     - { property: 'conference' }
@@ -12,6 +17,7 @@ easy_admin:
                     - { property: 'status', template: 'easy_admin/Submit/status.html.twig' }
                     - { property: 'users', type: 'array', label: 'Speakers' }
             form:
+                item_permission: SUBMIT_EDIT
                 fields:
                     - { type: 'group', columns: 6, icon: 'pencil', label: 'Submit' }
                     -   property: 'talk'

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -35,3 +35,4 @@ security:
             - ROLE_USER
             - TALK_SHOW
             - PARTICIPATION_SHOW
+            - SUBMIT_EDIT

--- a/src/Security/Voter/SubmitVoter.php
+++ b/src/Security/Voter/SubmitVoter.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Starfleet Project.
+ *
+ * (c) Starfleet <msantostefano@jolicode.com>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace App\Security\Voter;
+
+use App\Entity\Submit;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class SubmitVoter extends Voter
+{
+    private RoleHierarchyInterface $roleHierarchy;
+
+    public function __construct(RoleHierarchyInterface $roleHierarchy)
+    {
+        $this->roleHierarchy = $roleHierarchy;
+    }
+
+    protected function supports(string $attribute, $subject): bool
+    {
+        return \in_array($attribute, ['SUBMIT_EDIT'])
+            && $subject instanceof Submit;
+    }
+
+    /**
+     * @param Submit $submit
+     */
+    protected function voteOnAttribute(string $attribute, $submit, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (!$user instanceof UserInterface) {
+            return false;
+        }
+
+        $roles = $this->roleHierarchy->getReachableRoleNames($token->getRoleNames());
+
+        if (\in_array('SUBMIT_EDIT', $roles)) {
+            return true;
+        }
+
+        if ($submit->getUsers()->contains($user)) {
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
If we want to see submits we can't do it directly from the menu and we have to go to conferences -> show a conference -> click `open in new tab` in the submits field.

This feels really weird so I suggest we add it to the menu, especially since everything has been made ready for it.