### PR TITLE
Prevent slack notifications when a conference has no CfP url

### DIFF
--- a/src/Command/RemindEndingCfpCommand.php
+++ b/src/Command/RemindEndingCfpCommand.php
@@ -48,7 +48,7 @@ class RemindEndingCfpCommand extends Command
         foreach ($conferences as $conference) {
             $remainingDays = (int) ($conference->getCfpEndAt()->diff($today)->format('%a'));
 
-            if (\in_array($remainingDays, self::REMAINING_DAYS_STEPS, true)) {
+            if (\in_array($remainingDays, self::REMAINING_DAYS_STEPS, true) && null !== $conference->getCfpUrl()) {
                 $this->eventDispatcher->dispatch(new CfpEndingSoonEvent($conference, $remainingDays));
             }
         }

--- a/src/Event/CfpEndingSoonEvent.php
+++ b/src/Event/CfpEndingSoonEvent.php
@@ -76,12 +76,10 @@ class CfpEndingSoonEvent extends Event
             $cfpAttachment['fields'][] = $talksField;
         }
 
-        if (null !== $this->conference->getCfpUrl()) {
-            $actionsField = SlackNotifier::SHORT_FIELD;
-            $actionsField['title'] = 'Submit a talk';
-            $actionsField['value'] = sprintf('<%s|%s>', $this->conference->getCfpUrl(), 'Go to the CFP  👉');
-            $cfpAttachment['fields'][] = $actionsField;
-        }
+        $actionsField = SlackNotifier::SHORT_FIELD;
+        $actionsField['title'] = 'Submit a talk';
+        $actionsField['value'] = sprintf('<%s|%s>', $this->conference->getCfpUrl(), 'Go to the CFP  👉');
+        $cfpAttachment['fields'][] = $actionsField;
 
         return $cfpAttachment;
     }


### PR DESCRIPTION
Prevents notifications from being sent if a conference has no CfP url.