### PR TITLE
Improve Slack notification when a talk has no conferences

### DIFF
--- a/src/Event/NewTalkSubmittedEvent.php
+++ b/src/Event/NewTalkSubmittedEvent.php
@@ -37,19 +37,23 @@ class NewTalkSubmittedEvent extends Event
         $talkAttachment['title'] = $this->talk->getTitle();
         $talkAttachment['text'] = $this->talk->getIntro();
 
-        $submitsAttachment = SlackNotifier::ATTACHMENT;
-        $submitsAttachment['title'] = 'Submitted at : ';
+        if (0 < \count($this->submits)) {
+            $submitsAttachment = SlackNotifier::ATTACHMENT;
+            $submitsAttachment['title'] = 'Submitted at : ';
 
-        foreach ($this->submits as $submit) {
-            $conferenceField = SlackNotifier::LONG_FIELD;
-            $conference = '<'.$submit->getConference()->getSiteUrl().'|'.$submit->getConference()->getName().'>';
-            $status = Submit::STATUS_EMOJIS[$submit->getStatus()];
-            $author = $submit->reduceSpeakersNames();
+            foreach ($this->submits as $submit) {
+                $conferenceField = SlackNotifier::LONG_FIELD;
+                $conference = '<'.$submit->getConference()->getSiteUrl().'|'.$submit->getConference()->getName().'>';
+                $status = Submit::STATUS_EMOJIS[$submit->getStatus()];
+                $author = $submit->reduceSpeakersNames();
 
-            $conferenceField['value'] = sprintf('%s (%s) by %s', $conference, $status, $author);
-            $submitsAttachment['fields'][] = $conferenceField;
+                $conferenceField['value'] = sprintf('%s (%s) by %s', $conference, $status, $author);
+                $submitsAttachment['fields'][] = $conferenceField;
+            }
+
+            return [$talkAttachment, $submitsAttachment];
         }
 
-        return [$talkAttachment, $submitsAttachment];
+        return [$talkAttachment];
     }
 }


### PR DESCRIPTION
This is a slight improvement for when a user creates a talk and doesn't submit it to a conference right away.

Currently if someone does so the notification looks like this :
![current](https://user-images.githubusercontent.com/71645693/111169128-f9f96780-85a2-11eb-9d0d-708d77c3fee1.png)

Now it wouldn't display the submits field :
![future](https://user-images.githubusercontent.com/71645693/111169204-0a114700-85a3-11eb-855f-ead1dcfa604f.png)

