### PR TITLE
Fix conference_show route only working for attended conferences

### DIFF
--- a/src/Controller/ConferenceController.php
+++ b/src/Controller/ConferenceController.php
@@ -48,14 +48,8 @@ class ConferenceController extends AbstractController
     /**
      * @Route("/conferences/{slug}", name="conferences_show")
      */
-    public function showAction(string $slug, ConferenceRepository $conferenceRepository): Response
+    public function showAction(Conference $conference, ConferenceRepository $conferenceRepository): Response
     {
-        $conference = $conferenceRepository->findOneAttended($slug);
-
-        if (!$conference) {
-            throw $this->createNotFoundException("Conference with slug '$slug' not found.");
-        }
-
         return $this->render('conferences/show.html.twig', [
             'conference' => $conference,
         ]);

--- a/src/Repository/ConferenceRepository.php
+++ b/src/Repository/ConferenceRepository.php
@@ -64,17 +64,6 @@ class ConferenceRepository extends ServiceEntityRepository
             ;
     }
 
-    public function findOneAttended(string $slug): ?Conference
-    {
-        return $this->createAttendedQueryBuilder()
-            ->andWhere('c.slug = :slug')
-            ->setParameter('slug', $slug)
-            ->setMaxResults(1)
-            ->getQuery()
-            ->getOneOrNullResult()
-            ;
-    }
-
     /** @return \Generator<Conference>|null */
     public function getNullCoordinatesConferences(): ?\Generator
     {


### PR DESCRIPTION
Currently, almost all slack links are not working because the conference_show route only works with attended conferences.

This will allow all conferences to work with the show_conference route.