### PR TITLE
Fix notification bug and remove dates from conference names

### DIFF
--- a/src/Conferences/ConferencesHarvester.php
+++ b/src/Conferences/ConferencesHarvester.php
@@ -83,9 +83,8 @@ class ConferencesHarvester
                 } else {
                     $this->em->persist($conference);
                     ++$newConferencesCount;
+                    $fetchedConferences[] = $conference;
                 }
-
-                $fetchedConferences[] = $conference;
             }
 
             $this->em->flush();

--- a/src/Fetcher/ConfTechFetcher.php
+++ b/src/Fetcher/ConfTechFetcher.php
@@ -142,8 +142,9 @@ class ConfTechFetcher implements FetcherInterface
         $conference = new Conference();
         $conference->setSource(self::SOURCE);
         $conference->setSlug($slug);
-        $conference->setName($rawConference['name']);
         $conference->setStartAt($startDate);
+        $name = trim(str_replace($startDate->format('Y'), '', $rawConference['name']));
+        $conference->setName($name);
         $conference->setSiteUrl($rawConference['url']);
         $conference->setOnline($online);
         $conference->addTag($tag);

--- a/src/Fetcher/JoindApiFetcher.php
+++ b/src/Fetcher/JoindApiFetcher.php
@@ -174,8 +174,9 @@ class JoindApiFetcher implements FetcherInterface
         $conference = new Conference();
         $conference->setSource(self::SOURCE);
         $conference->setSlug($slug);
-        $conference->setName($rawConference['name']);
         $conference->setStartAt($startDate);
+        $name = trim(str_replace($startDate->format('Y'), '', $rawConference['name']));
+        $conference->setName($name);
         $conference->setSiteUrl($rawConference['href']);
 
         $lowerLocation = strtolower($rawConference['location']);

--- a/src/Fetcher/SymfonyFetcher.php
+++ b/src/Fetcher/SymfonyFetcher.php
@@ -87,6 +87,8 @@ class SymfonyFetcher implements FetcherInterface
         if (\array_key_exists('starts_at', $rawConference)) {
             $startDate = new \DateTimeImmutable($rawConference['starts_at']['date']);
             $conference->setStartAt($startDate);
+            $name = trim(str_replace($startDate->format('Y'), '', $rawConference['name']));
+            $conference->setName($name);
         }
 
         if (\array_key_exists('ends_at', $rawConference) && $rawConference['ends_at']) {

--- a/src/Fetcher/TululaFetcher.php
+++ b/src/Fetcher/TululaFetcher.php
@@ -197,8 +197,9 @@ class TululaFetcher implements FetcherInterface
         $conference = new Conference();
         $conference->setSource(self::SOURCE);
         $conference->setSlug($rawConference['slug']);
-        $conference->setName($rawConference['name']);
         $conference->setStartAt($startDate);
+        $name = trim(str_replace($startDate->format('Y'), '', $rawConference['name']));
+        $conference->setName($name);
         $conference->setEndAt($endDate);
         $conference->setCfpEndAt($cfpEndDate);
         $conference->setSiteUrl($rawConference['url']);


### PR DESCRIPTION
We were sending a ntofication for every single fetched conference and not only for new ones, so this fixes it.

It also prevents conferences from being registered twice if one has its date in its name while the other has not.