### PR TITLE
Help with manually added online conferences

### DIFF
--- a/src/Controller/FrontController.php
+++ b/src/Controller/FrontController.php
@@ -17,7 +17,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
-class ConferenceController extends AbstractController
+class FrontController extends AbstractController
 {
     /**
      * @Route("/", name="conferences_list")

--- a/src/SlackNotifier.php
+++ b/src/SlackNotifier.php
@@ -134,25 +134,26 @@ class SlackNotifier
             $conferenceLink = $conference->getName();
         }
         $countdown = sprintf('in *%d day%s* !', $remainingDays, $remainingDays > 1 ? 's' : '');
+        $location = $conference->isOnline() ? 'Online' : $conference->getCity();
 
         switch ($remainingDays) {
             case 30:
-                $cfpAttachment['pretext'] = sprintf($template, $conferenceLink, $conference->getCity(), $countdown.' 😀');
+                $cfpAttachment['pretext'] = sprintf($template, $conferenceLink, $location, $countdown.' 😀');
                 break;
             case 20:
-                $cfpAttachment['pretext'] = sprintf($template, $conferenceLink, $conference->getCity(), $countdown.' 🙂');
+                $cfpAttachment['pretext'] = sprintf($template, $conferenceLink, $location, $countdown.' 🙂');
                 break;
             case 10:
-                $cfpAttachment['pretext'] = sprintf($template, $conferenceLink, $conference->getCity(), $countdown.' 😮');
+                $cfpAttachment['pretext'] = sprintf($template, $conferenceLink, $location, $countdown.' 😮');
                 break;
             case 5:
-                $cfpAttachment['pretext'] = sprintf($template, $conferenceLink, $conference->getCity(), $countdown.' 😨');
+                $cfpAttachment['pretext'] = sprintf($template, $conferenceLink, $location, $countdown.' 😨');
                 break;
             case 1:
-                $cfpAttachment['pretext'] = sprintf($template, $conferenceLink, $conference->getCity(), $countdown.' 😰');
+                $cfpAttachment['pretext'] = sprintf($template, $conferenceLink, $location, $countdown.' 😰');
                 break;
             case 0:
-                $cfpAttachment['pretext'] = sprintf($template, $conferenceLink, $conference->getCity(), '*today* ! 😱');
+                $cfpAttachment['pretext'] = sprintf($template, $conferenceLink, $location, '*today* ! 😱');
                 break;
         }
 


### PR DESCRIPTION
This will set the city to Online for online conferences that were added manually.

Previously someone could add a new conference, set it to be online, and leave the City field empty, which would mess with notifications : 
![bug](https://user-images.githubusercontent.com/71645693/114691606-24605100-9d18-11eb-9c2e-db0e0f773332.png)

I also renamed the ConferenceController to FrontController, which is a more accurate name IMO