### PR TITLE
Fix notification if all conferences are excluded

### DIFF
--- a/src/Notifiers/Slack/SlackNotifier.php
+++ b/src/Notifiers/Slack/SlackNotifier.php
@@ -136,31 +136,31 @@ class SlackNotifier
     {
         $header = $this->slackBlocksBuilder->buildHeader('New conferences of the day');
 
-        if (0 === \count($conferences)) {
-            $conferencesBlocks = [$this->slackBlocksBuilder->buildSimpleSection('No conferences were added today !')];
-        } else {
-            $conferencesBlocks = [];
+        $conferencesBlocks = [];
 
-            foreach ($conferences as $conference) {
-                if (null === $conference->getCfpUrl()) {
-                    continue;
-                }
-
-                if ($conference->getExcluded()) {
-                    continue;
-                }
-
-                $conferenceUrl = $this->router->generate('easyadmin', [
-                    'id' => $conference->getId(),
-                    'entity' => 'NextConference',
-                    'action' => 'show',
-                ], UrlGeneratorInterface::ABSOLUTE_URL);
-
-                $location = $conference->isOnline() ? 'Online' : sprintf(':flag-%s:', $conference->getCountry());
-
-                $conferenceText = sprintf('*<%s|%s>*, %s (<%s|Go to CFP>)', $conferenceUrl, $conference->getName(), $location, $conference->getCfpUrl());
-                $conferencesBlocks[] = $this->slackBlocksBuilder->buildSectionWithButton($conferenceText, 'Mute this conference', 'Mute Conference', $conference->getId());
+        foreach ($conferences as $conference) {
+            if (null === $conference->getCfpUrl()) {
+                continue;
             }
+
+            if ($conference->getExcluded()) {
+                continue;
+            }
+
+            $conferenceUrl = $this->router->generate('easyadmin', [
+                'id' => $conference->getId(),
+                'entity' => 'NextConference',
+                'action' => 'show',
+            ], UrlGeneratorInterface::ABSOLUTE_URL);
+
+            $location = $conference->isOnline() ? 'Online' : sprintf(':flag-%s:', $conference->getCountry());
+
+            $conferenceText = sprintf('*<%s|%s>*, %s (<%s|Go to CFP>)', $conferenceUrl, $conference->getName(), $location, $conference->getCfpUrl());
+            $conferencesBlocks[] = $this->slackBlocksBuilder->buildSectionWithButton($conferenceText, 'Mute this conference', 'Mute Conference', $conference->getId());
+        }
+
+        if (0 === \count($conferencesBlocks)) {
+            $conferencesBlocks = [$this->slackBlocksBuilder->buildSimpleSection('No conferences were added today !')];
         }
 
         return [


### PR DESCRIPTION
Currently if all new conferences are exlcuded or don't have a CFP Url, there is no Slack message at all about conferences.

This should fix it and say "no conferences today".