### PR TITLE
Fix bug when editing an excluded conference

### DIFF
--- a/config/packages/easy_admin/conference.yaml
+++ b/config/packages/easy_admin/conference.yaml
@@ -49,7 +49,7 @@ easy_admin:
                     - { property: 'source', type: 'text' }
                     - { property: 'tags', type: 'array' }
             form:
-                fields:
+                fields: &conferencesEdit
                     - { type: 'group', columns: 4, icon: 'pencil', label: 'Conference' }
                     - { property: 'name', type: 'text' }
                     - { property: 'city', type: 'text' }
@@ -85,3 +85,6 @@ easy_admin:
             show:
                 fields:
                     <<: *conferenceShow
+            form:
+                fields:
+                    <<: *conferencesEdit


### PR DESCRIPTION
Currently, if we try to edit an excluded conference, we have this error :

`Object of class App\Entity\Participation could not be converted to string`
