### PR TITLE
Fix excluded conferences bug

### DIFF
--- a/src/Conferences/ConferencesHarvester.php
+++ b/src/Conferences/ConferencesHarvester.php
@@ -150,11 +150,6 @@ class ConferencesHarvester
             $updated = true;
         }
 
-        if ($conference->getExcluded() !== $existingConference->getExcluded()) {
-            $existingConference->setExcluded($conference->getExcluded());
-            $updated = true;
-        }
-
         if ($conference->isOnline() !== $existingConference->isOnline()) {
             $existingConference->setOnline($conference->isOnline());
             $updated = true;


### PR DESCRIPTION
Currently, excluded conferences are always included again if their CFP has not ended, making the exclude feature not working.