### PR TITLE
Remove endDate check for same conferences and clean some code

### DIFF
--- a/src/Conferences/ConferencesHarvester.php
+++ b/src/Conferences/ConferencesHarvester.php
@@ -46,7 +46,7 @@ class ConferencesHarvester
     /** @return array<string,int> */
     public function harvest(): array
     {
-        $fetchersAmount = \count($this->fetchers);
+        $fetchersAmount = iterator_count($this->fetchers);
         $currentFetcher = 0;
         $updatedConferencesCount = 0;
         $newConferencesCount = 0;

--- a/src/Notifiers/Slack/SlackNotifier.php
+++ b/src/Notifiers/Slack/SlackNotifier.php
@@ -150,10 +150,8 @@ class SlackNotifier
                     continue;
                 }
 
-                $conferenceUrl = $this->router->generate('easyadmin', [
-                    'id' => $conference->getId(),
-                    'entity' => 'NextConference',
-                    'action' => 'show',
+                $conferenceUrl = $this->router->generate('conferences_show', [
+                    'slug' => $conference->getSlug(),
                 ], UrlGeneratorInterface::ABSOLUTE_URL);
 
                 $location = $conference->isOnline() ? 'Online' : sprintf(':flag-%s:', $conference->getCountry());
@@ -209,10 +207,8 @@ class SlackNotifier
             $cfpsBlock[] = $this->slackBlocksBuilder->buildSimpleSection($cfpText);
 
             foreach ($conferences as $conference) {
-                $conferenceUrl = $this->router->generate('easyadmin', [
-                    'id' => $conference->getId(),
-                    'entity' => 'NextConference',
-                    'action' => 'show',
+                $conferenceUrl = $this->router->generate('conferences_show', [
+                    'slug' => $conference->getSlug(),
                 ], UrlGeneratorInterface::ABSOLUTE_URL);
 
                 $location = $conference->isOnline() ? 'Online' : sprintf(':flag-%s:', $conference->getCountry());

--- a/src/Repository/ConferenceRepository.php
+++ b/src/Repository/ConferenceRepository.php
@@ -104,11 +104,9 @@ class ConferenceRepository extends ServiceEntityRepository
     {
         return $this->createQueryBuilder('c')
             ->andWhere('c.startAt = :startAt')
-            ->andWhere('c.endAt = :endAt')
             ->andWhere('levenshtein(c.name, :name) < 4')
             ->setParameters([
                 'startAt' => $conference->getStartAt(),
-                'endAt' => $conference->getEndAt(),
                 'name' => $conference->getName(),
             ])
             ->setMaxResults(1)

--- a/tests/Conference/ConferenceHarvesterTest.php
+++ b/tests/Conference/ConferenceHarvesterTest.php
@@ -126,7 +126,7 @@ class ConferenceHarvesterTest extends KernelTestCase
             ->dispatch(Argument::type(DailyNotificationEvent::class));
 
         $harvester = new ConferencesHarvester(
-            [$fetcherProphecy->reveal()],
+            new \ArrayIterator([$fetcherProphecy->reveal()]),
             $fetcherConfigurationRepository->reveal(),
             $conferenceFilterRepository->reveal(),
             $conferenceRepository->reveal(),

--- a/tests/Functional/FrontControllerTest.php
+++ b/tests/Functional/FrontControllerTest.php
@@ -13,7 +13,7 @@ namespace App\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-class ConferenceControllerTest extends WebTestCase
+class FrontControllerTest extends WebTestCase
 {
     public function testConferencesWithValidatedParticipationsAreDisplayed()
     {

--- a/tests/Notifiers/Slack/SlackNotifierTest.php
+++ b/tests/Notifiers/Slack/SlackNotifierTest.php
@@ -118,11 +118,7 @@ class SlackNotifierTest extends WebTestCase
         $router
             ->generate(
                 Argument::type('string'),
-                [
-                    'id' => 1,
-                    'entity' => 'NextConference',
-                    'action' => 'show',
-                ],
+                ['slug' => 'test-slug'],
                 Argument::type('integer')
             )
             ->willReturn('Route URL');
@@ -150,6 +146,7 @@ class SlackNotifierTest extends WebTestCase
         $conference->setOnline(false);
         $conference->setExcluded($excluded);
         $conference->setCountry('Test Country');
+        $conference->setSlug('test-slug');
 
         $conferenceReflection = new \ReflectionClass(Conference::class);
         $conferenceId = $conferenceReflection->getProperty('id');


### PR DESCRIPTION
This fixes an issue when two sources add the same conference but don't set their end date to the same date. When this happens, we then have duplicates of this conference in the database.

Conferences links in Slack will now point to the front rather than to the admin