### PR TITLE
Prevent empty string CFP URL from sending notifications

### DIFF
--- a/src/Fetcher/ConfTechFetcher.php
+++ b/src/Fetcher/ConfTechFetcher.php
@@ -160,20 +160,20 @@ class ConfTechFetcher implements FetcherInterface
             $conference->setCity($city);
         }
 
-        if (\array_key_exists('endDate', $rawConference)) {
+        if (\array_key_exists('endDate', $rawConference) && $rawConference['endDate']) {
             $endDate = new \DateTimeImmutable($rawConference['endDate']);
             $conference->setEndAt($endDate);
         }
 
-        if (\array_key_exists('description', $rawConference)) {
+        if (\array_key_exists('description', $rawConference) && $rawConference['description']) {
             $conference->setDescription($rawConference['description']);
         }
 
-        if (\array_key_exists('cfpUrl', $rawConference)) {
+        if (\array_key_exists('cfpUrl', $rawConference) && $rawConference['cfpUrl']) {
             $conference->setCfpUrl($rawConference['cfpUrl']);
         }
 
-        if (\array_key_exists('cfpEndDate', $rawConference)) {
+        if (\array_key_exists('cfpEndDate', $rawConference) && $rawConference['cfpEndDate']) {
             $cfpEndAt = new \DateTimeImmutable($rawConference['cfpEndDate']);
             $conference->setCfpEndAt($cfpEndAt);
         }

--- a/src/Fetcher/JoindApiFetcher.php
+++ b/src/Fetcher/JoindApiFetcher.php
@@ -193,20 +193,20 @@ class JoindApiFetcher implements FetcherInterface
             $conference->addTag($tag);
         }
 
-        if (\array_key_exists('end_date', $rawConference)) {
+        if (\array_key_exists('end_date', $rawConference) && $rawConference['end_date']) {
             $endDate = new \DateTimeImmutable($rawConference['end_date']);
             $conference->setEndAt($endDate);
         }
 
-        if (\array_key_exists('description', $rawConference)) {
+        if (\array_key_exists('description', $rawConference) && $rawConference['description']) {
             $conference->setDescription($rawConference['description']);
         }
 
-        if (\array_key_exists('cfp_url', $rawConference)) {
+        if (\array_key_exists('cfp_url', $rawConference) && $rawConference['cfp_url']) {
             $conference->setCfpUrl($rawConference['cfp_url']);
         }
 
-        if (\array_key_exists('cfp_end_date', $rawConference)) {
+        if (\array_key_exists('cfp_end_date', $rawConference) && $rawConference['cfp_end_date']) {
             $cfpEndAt = new \DateTimeImmutable($rawConference['cfp_end_date']);
             $conference->setCfpEndAt($cfpEndAt);
         }

--- a/src/Fetcher/TululaFetcher.php
+++ b/src/Fetcher/TululaFetcher.php
@@ -191,8 +191,6 @@ class TululaFetcher implements FetcherInterface
         }
 
         $startDate = new \DateTimeImmutable($rawConference['dateStart']);
-        $endDate = new \DateTimeImmutable($rawConference['dateEnd']);
-        $cfpEndDate = new \DateTimeImmutable($rawConference['cfpDateEnd']);
 
         $conference = new Conference();
         $conference->setSource(self::SOURCE);
@@ -200,10 +198,7 @@ class TululaFetcher implements FetcherInterface
         $conference->setStartAt($startDate);
         $name = trim(str_replace($startDate->format('Y'), '', $rawConference['name']));
         $conference->setName($name);
-        $conference->setEndAt($endDate);
-        $conference->setCfpEndAt($cfpEndDate);
         $conference->setSiteUrl($rawConference['url']);
-        $conference->setCfpUrl($rawConference['cfpUrl']);
 
         foreach ($rawConference['tags'] as $tag) {
             $conference->addTag($tag['name']);
@@ -216,6 +211,20 @@ class TululaFetcher implements FetcherInterface
             $conference->setCity($city);
             $conference->setCountry($rawConference['venue']['countryCode']);
             $conference->setCoordinates($coords);
+        }
+
+        if (\array_key_exists('dateEnd', $rawConference) && $rawConference['dateEnd']) {
+            $endDate = new \DateTimeImmutable($rawConference['dateEnd']);
+            $conference->setEndAt($endDate);
+        }
+
+        if (\array_key_exists('cfpUrl', $rawConference) && $rawConference['cfpUrl']) {
+            $conference->setCfpUrl($rawConference['cfpUrl']);
+        }
+
+        if (\array_key_exists('cfpDateEnd', $rawConference) && $rawConference['cfpDateEnd']) {
+            $cfpEndAt = new \DateTimeImmutable($rawConference['cfpDateEnd']);
+            $conference->setCfpEndAt($cfpEndAt);
         }
 
         return $conference;

--- a/src/Notifiers/Slack/SlackNotifier.php
+++ b/src/Notifiers/Slack/SlackNotifier.php
@@ -142,21 +142,21 @@ class SlackNotifier
             $conferencesBlocks = [];
 
             foreach ($conferences as $conference) {
-                if (null === $conference->getCfpUrl()) {
-                    continue;
-                }
-
                 if ($conference->getExcluded()) {
                     continue;
                 }
 
+                $location = $conference->isOnline() ? 'Online' : sprintf(':flag-%s:', $conference->getCountry());
                 $conferenceUrl = $this->router->generate('conferences_show', [
                     'slug' => $conference->getSlug(),
                 ], UrlGeneratorInterface::ABSOLUTE_URL);
 
-                $location = $conference->isOnline() ? 'Online' : sprintf(':flag-%s:', $conference->getCountry());
+                if ($conference->getCfpUrl()) {
+                    $conferenceText = sprintf('*<%s|%s>*, %s (<%s|Go to CFP>)', $conferenceUrl, $conference->getName(), $location, $conference->getCfpUrl());
+                } else {
+                    $conferenceText = sprintf('*<%s|%s>*, %s (No CFP page)', $conferenceUrl, $conference->getName(), $location);
+                }
 
-                $conferenceText = sprintf('*<%s|%s>*, %s (<%s|Go to CFP>)', $conferenceUrl, $conference->getName(), $location, $conference->getCfpUrl());
                 $conferencesBlocks[] = $this->slackBlocksBuilder->buildSectionWithButton($conferenceText, 'Mute this conference', 'Mute Conference', $conference->getId());
             }
         }
@@ -212,7 +212,12 @@ class SlackNotifier
                 ], UrlGeneratorInterface::ABSOLUTE_URL);
 
                 $location = $conference->isOnline() ? 'Online' : sprintf(':flag-%s:', $conference->getCountry());
-                $conferenceText = sprintf('*<%s|%s>*, %s (<%s|Go to CFP>)', $conferenceUrl, $conference->getName(), $location, $conference->getCfpUrl());
+
+                if ($conference->getCfpUrl()) {
+                    $conferenceText = sprintf('*<%s|%s>*, %s (<%s|Go to CFP>)', $conferenceUrl, $conference->getName(), $location, $conference->getCfpUrl());
+                } else {
+                    $conferenceText = sprintf('*<%s|%s>*, %s (No CFP page)', $conferenceUrl, $conference->getName(), $location);
+                }
 
                 if ($conference->getSubmits()->count() > 0) {
                     $conferenceText .= sprintf("\n%d Talks were submitted by colleagues for %s !", \count($conference->getSubmits()), $conference->getName());

--- a/tests/Notifiers/Slack/SlackNotifierTest.php
+++ b/tests/Notifiers/Slack/SlackNotifierTest.php
@@ -98,15 +98,6 @@ class SlackNotifierTest extends WebTestCase
             // One for $testConference, one to say no ending CFP.
             'expectedSections' => 2,
         ];
-
-        $noCfpUrlConference = $this->createConference(new \DateTime(), cfpUrl: null);
-
-        yield 'Test conference with no CFP URL is not sending notifications' => [
-            'newConferences' => [$testConference, $noCfpUrlConference],
-            'endingCfps' => [],
-            // One for $testConference, one to say no ending CFP.
-            'expectedSections' => 2,
-        ];
     }
 
     private function createSlackNotifier(array $endingCfps, HttpClientInterface $client): SlackNotifier
@@ -137,12 +128,12 @@ class SlackNotifierTest extends WebTestCase
         );
     }
 
-    private function createConference(\DateTimeInterface $cfpEndAt, bool $excluded = false, ?string $cfpUrl = 'Test URL')
+    private function createConference(\DateTimeInterface $cfpEndAt, bool $excluded = false)
     {
         $conference = new Conference();
         $conference->setName('Test Conference');
         $conference->setCfpEndAt($cfpEndAt);
-        $conference->setCfpUrl($cfpUrl);
+        $conference->setCfpUrl('https://starfleet.jolicode.com');
         $conference->setOnline(false);
         $conference->setExcluded($excluded);
         $conference->setCountry('Test Country');


### PR DESCRIPTION
Currently, some fetchers allow conferences to have an empty string as their CFP URL, and the notifier doesn't prevent empty CFP URL from sending notifications, which it should do.