### PR TITLE
Fix bug when muting last conference in Slack notification

### DIFF
--- a/src/Controller/SlackController.php
+++ b/src/Controller/SlackController.php
@@ -59,10 +59,16 @@ class SlackController extends AbstractController
 
         $blocks = $this->slackNotifier->buildDailyBlocks($dailyConferences, $endingCfps);
 
-        $body = [
-            'replace_original' => true,
-            'blocks' => $blocks,
-        ];
+        if ($blocks) {
+            $body = [
+                'replace_original' => true,
+                'blocks' => $blocks,
+            ];
+        } else {
+            $body = [
+                'delete_original' => true,
+            ];
+        }
 
         $this->httpClient->request('POST', $payload['response_url'], [
             'headers' => ['Content-type' => 'application/json'],


### PR DESCRIPTION
Currently, muting the last conference of the notification ends up in a 500, now this should delete the message.