### PR TITLE
Fix notification bug when updating a submit through a talk

### DIFF
--- a/src/DataFixtures/FixtureBuilder.php
+++ b/src/DataFixtures/FixtureBuilder.php
@@ -59,6 +59,7 @@ class FixtureBuilder
 
         $submit->setSubmittedAt($description['submittedAt']);
         $submit->setStatus($description['status']);
+        $submit->resetStatusChanged();
         $submit->setConference($description['conference']);
         $submit->setTalk($description['talk']);
 


### PR DESCRIPTION
If someone tries tu update a submit through its talk, the notification isn't fired, so this fixes it.