### PR TITLE
Add cron to update past submits

### DIFF
--- a/src/Command/ConferenceStatusesCommand.php
+++ b/src/Command/ConferenceStatusesCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Starfleet Project.
+ *
+ * (c) Starfleet <msantostefano@jolicode.com>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace App\Command;
+
+use App\Repository\SubmitRepository;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ConferenceStatusesCommand extends Command
+{
+    public function __construct(
+        private SubmitRepository $submitRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('starfleet:submits:statuses');
+        $this->setDescription('Updates the statuses of past submits');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->submitRepository->updateDoneSubmits();
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Repository/SubmitRepositoryTest.php
+++ b/tests/Repository/SubmitRepositoryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Starfleet Project.
+ *
+ * (c) Starfleet <msantostefano@jolicode.com>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace App\Tests\Repository;
+
+use App\Entity\Submit;
+use App\Repository\SubmitRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class SubmitRepositoryTest extends KernelTestCase
+{
+    public function testUpdateDoneSubmitsWork()
+    {
+        static::bootKernel();
+
+        $submitRepository = static::$container->get(SubmitRepository::class);
+        $submitRepository->updateDoneSubmits();
+
+        $today = new \DateTime();
+        $today->setTime(0, 0);
+
+        $pastAcceptedSubmitsCount = $submitRepository->createQueryBuilder('s')
+            ->select('count(s)')
+            ->innerJoin('s.conference', 'c')
+            ->andWhere('s.status = :status_accepted')
+            ->andWhere('c.endAt < :today')
+            ->setParameters([
+                'status_accepted' => Submit::STATUS_ACCEPTED,
+                'today' => $today,
+            ])
+            ->getQuery()
+            ->getSingleScalarResult()
+        ;
+
+        self::assertSame(0, $pastAcceptedSubmitsCount);
+    }
+}


### PR DESCRIPTION
This will add a command that should be a cron to automatically set the status of accepted submits to done if the conference is over.
It will also add a reminder for the user if they have a pending submit for a conference which is over.

This is to prevent users from forgetting to change the marking of their conferences and leaving irrelevant entries in the database.