### PR TITLE
Remove fixtures from tests

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -153,7 +153,6 @@ def tests(c):
     Launch unit and functional tests
     """
     with Builder(c):
-        fixtures(c)
         docker_compose_run(c, 'php ./vendor/bin/simple-phpunit')
 
 


### PR DESCRIPTION
In #213 we added foundry to alls tests that were relying on application fixtures to work.

However, we still load fixtures when running tests, slowing it by quite a bit. But we dont't need them at all anymore, so we should just get rid of them.