### PR TITLE
Fix various issues with Submits

### DIFF
--- a/migrations/Version20210910101222.php
+++ b/migrations/Version20210910101222.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Starfleet Project.
+ *
+ * (c) Starfleet <msantostefano@jolicode.com>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20210910101222 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE abstract_notification DROP CONSTRAINT FK_2C3FCFFB8AAB0BD7');
+        $this->addSql('ALTER TABLE abstract_notification DROP CONSTRAINT FK_2C3FCFFB37BC4DC6');
+        $this->addSql('ALTER TABLE abstract_notification DROP CONSTRAINT FK_2C3FCFFB6ACE3B73');
+        $this->addSql('ALTER TABLE abstract_notification DROP CONSTRAINT FK_2C3FCFFB604B8382');
+        $this->addSql('ALTER TABLE abstract_notification ADD talk_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE abstract_notification ADD CONSTRAINT FK_2C3FCFFB6F0601D5 FOREIGN KEY (talk_id) REFERENCES talk (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE abstract_notification ADD CONSTRAINT FK_2C3FCFFB8AAB0BD7 FOREIGN KEY (submit_id) REFERENCES submit (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE abstract_notification ADD CONSTRAINT FK_2C3FCFFB37BC4DC6 FOREIGN KEY (emitter_id) REFERENCES users (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE abstract_notification ADD CONSTRAINT FK_2C3FCFFB6ACE3B73 FOREIGN KEY (participation_id) REFERENCES participation (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE abstract_notification ADD CONSTRAINT FK_2C3FCFFB604B8382 FOREIGN KEY (conference_id) REFERENCES conference (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_2C3FCFFB6F0601D5 ON abstract_notification (talk_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE abstract_notification DROP CONSTRAINT FK_2C3FCFFB6F0601D5');
+        $this->addSql('ALTER TABLE abstract_notification DROP CONSTRAINT fk_2c3fcffb8aab0bd7');
+        $this->addSql('ALTER TABLE abstract_notification DROP CONSTRAINT fk_2c3fcffb37bc4dc6');
+        $this->addSql('ALTER TABLE abstract_notification DROP CONSTRAINT fk_2c3fcffb6ace3b73');
+        $this->addSql('ALTER TABLE abstract_notification DROP CONSTRAINT fk_2c3fcffb604b8382');
+        $this->addSql('DROP INDEX IDX_2C3FCFFB6F0601D5');
+        $this->addSql('ALTER TABLE abstract_notification DROP talk_id');
+        $this->addSql('ALTER TABLE abstract_notification ADD CONSTRAINT fk_2c3fcffb8aab0bd7 FOREIGN KEY (submit_id) REFERENCES submit (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE abstract_notification ADD CONSTRAINT fk_2c3fcffb37bc4dc6 FOREIGN KEY (emitter_id) REFERENCES users (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE abstract_notification ADD CONSTRAINT fk_2c3fcffb6ace3b73 FOREIGN KEY (participation_id) REFERENCES participation (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE abstract_notification ADD CONSTRAINT fk_2c3fcffb604b8382 FOREIGN KEY (conference_id) REFERENCES conference (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+}

--- a/src/Controller/UserAccount/SubmitController.php
+++ b/src/Controller/UserAccount/SubmitController.php
@@ -14,6 +14,7 @@ namespace App\Controller\UserAccount;
 use App\Entity\Conference;
 use App\Entity\Submit;
 use App\Event\Notification\NewSubmitEvent;
+use App\Event\Notification\SubmitCancelledEvent;
 use App\Event\Notification\SubmitStatusChangedEvent;
 use App\Form\UserAccount\SubmitType;
 use App\Repository\ConferenceRepository;
@@ -255,6 +256,8 @@ class SubmitController extends AbstractController
         if (!$this->isCsrfTokenValid('', $request->request->get('token'))) {
             throw new AccessDeniedException();
         }
+
+        $this->eventDispatcher->dispatch(new SubmitCancelledEvent($submit));
 
         $this->em->remove($submit);
         $this->em->flush();

--- a/src/DataFixtures/NotificationsFixtures.php
+++ b/src/DataFixtures/NotificationsFixtures.php
@@ -15,6 +15,7 @@ use App\Entity\Notifications\AbstractNotification;
 use App\Factory\Notifications\NewFeaturedConferenceNotificationFactory;
 use App\Factory\Notifications\NewSubmitNotificationFactory;
 use App\Factory\Notifications\ParticipationStatusChangedNotificationFactory;
+use App\Factory\Notifications\SubmitCancelledNotificationFactory;
 use App\Factory\Notifications\SubmitStatusChangedNotificationFactory;
 use App\Factory\UserFactory;
 use Doctrine\Bundle\FixturesBundle\Fixture;
@@ -45,11 +46,12 @@ class NotificationsFixtures extends Fixture implements DependentFixtureInterface
 
     private function createRandomNotification(Proxy $user): AbstractNotification
     {
-        $proxy = match (random_int(1, 4)) {
+        $proxy = match (random_int(1, 5)) {
             1 => NewFeaturedConferenceNotificationFactory::findOrCreate(['targetUser' => $user]),
             2 => ParticipationStatusChangedNotificationFactory::findOrCreate(['targetUser' => $user]),
             3 => NewSubmitNotificationFactory::findOrCreate(['targetUser' => $user]),
             4 => SubmitStatusChangedNotificationFactory::findOrCreate(['targetUser' => $user]),
+            5 => SubmitCancelledNotificationFactory::findOrCreate(['targetUser' => $user]),
             default => NewSubmitNotificationFactory::findOrCreate(['targetUser' => $user]),
         };
 

--- a/src/Entity/Notifications/AbstractNotification.php
+++ b/src/Entity/Notifications/AbstractNotification.php
@@ -26,7 +26,8 @@ use Symfony\Component\Validator\Constraints as Assert;
  *      "NewSubmit" = "NewSubmitNotification",
  *      "submitStatusChanged" = "SubmitStatusChangedNotification",
  *      "participationStatusChangedNotification" = "ParticipationStatusChangedNotification",
- *      "newFeaturedConference" = "NewFeaturedConferenceNotification"
+ *      "newFeaturedConference" = "NewFeaturedConferenceNotification",
+ *      "submitCancelled" = "SubmitCancelledNotification"
  * })
  */
 abstract class AbstractNotification
@@ -36,12 +37,14 @@ abstract class AbstractNotification
     public const TRIGGER_SUBMIT_STATUS_CHANGED = 'submit_status_changed';
     public const TRIGGER_PARTICIPATION_STATUS_CHANGED = 'participation_status_changed';
     public const TRIGGER_NEW_FEATURED_CONFERENCE = 'new_featured_conference';
+    public const TRIGGER_SUBMIT_CANCELLED = 'submit_cancelled';
 
     public const TRIGGERS = [
         self::TRIGGER_NEW_SUBMIT,
         self::TRIGGER_SUBMIT_STATUS_CHANGED,
         self::TRIGGER_PARTICIPATION_STATUS_CHANGED,
         self::TRIGGER_NEW_FEATURED_CONFERENCE,
+        self::TRIGGER_SUBMIT_CANCELLED,
     ];
 
     /**

--- a/src/Entity/Notifications/NewFeaturedConferenceNotification.php
+++ b/src/Entity/Notifications/NewFeaturedConferenceNotification.php
@@ -22,7 +22,7 @@ class NewFeaturedConferenceNotification extends AbstractNotification
 {
     /**
      * @ORM\ManyToOne(targetEntity=Conference::class)
-     * @ORM\JoinColumn()
+     * @ORM\JoinColumn(onDelete="CASCADE")
      */
     private ?Conference $conference;
 

--- a/src/Entity/Notifications/ParticipationStatusChangedNotification.php
+++ b/src/Entity/Notifications/ParticipationStatusChangedNotification.php
@@ -22,13 +22,13 @@ class ParticipationStatusChangedNotification extends AbstractNotification
 {
     /**
      * @ORM\ManyToOne(targetEntity=Participation::class)
-     * @ORM\JoinColumn()
+     * @ORM\JoinColumn(onDelete="CASCADE")
      */
     private ?Participation $participation;
 
     /**
      * @ORM\ManyToOne(targetEntity=User::class)
-     * @ORM\JoinColumn()
+     * @ORM\JoinColumn(onDelete="CASCADE")
      */
     private ?User $emitter;
 

--- a/src/Entity/Notifications/SubmitCancelledNotification.php
+++ b/src/Entity/Notifications/SubmitCancelledNotification.php
@@ -11,20 +11,27 @@
 
 namespace App\Entity\Notifications;
 
-use App\Entity\Submit;
+use App\Entity\Conference;
+use App\Entity\Talk;
 use App\Entity\User;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity()
  */
-class NewSubmitNotification extends AbstractNotification
+class SubmitCancelledNotification extends AbstractNotification
 {
     /**
-     * @ORM\ManyToOne(targetEntity=Submit::class)
+     * @ORM\ManyToOne(targetEntity=Talk::class)
      * @ORM\JoinColumn(onDelete="CASCADE")
      */
-    private ?Submit $submit;
+    private ?Talk $talk;
+
+    /**
+     * @ORM\ManyToOne(targetEntity=Conference::class)
+     * @ORM\JoinColumn(onDelete="CASCADE")
+     */
+    private ?Conference $conference;
 
     /**
      * @ORM\ManyToOne(targetEntity=User::class)
@@ -32,16 +39,22 @@ class NewSubmitNotification extends AbstractNotification
      */
     private ?User $emitter;
 
-    public function __construct(Submit $submit, User $emitter, User $targetUser, string $trigger)
+    public function __construct(Talk $talk, Conference $conference, User $emitter, User $targetUser, string $trigger)
     {
-        $this->submit = $submit;
+        $this->talk = $talk;
+        $this->conference = $conference;
         $this->emitter = $emitter;
         parent::__construct($targetUser, $trigger);
     }
 
-    public function getSubmit(): Submit
+    public function getTalk(): Talk
     {
-        return $this->submit;
+        return $this->talk;
+    }
+
+    public function getConference(): Conference
+    {
+        return $this->conference;
     }
 
     public function getEmitter(): User

--- a/src/Entity/Notifications/SubmitStatusChangedNotification.php
+++ b/src/Entity/Notifications/SubmitStatusChangedNotification.php
@@ -22,13 +22,13 @@ class SubmitStatusChangedNotification extends AbstractNotification
 {
     /**
      * @ORM\ManyToOne(targetEntity=Submit::class)
-     * @ORM\JoinColumn()
+     * @ORM\JoinColumn(onDelete="CASCADE")
      */
     private ?Submit $submit;
 
     /**
      * @ORM\ManyToOne(targetEntity=User::class)
-     * @ORM\JoinColumn()
+     * @ORM\JoinColumn(onDelete="CASCADE")
      */
     private ?User $emitter;
 

--- a/src/Entity/Submit.php
+++ b/src/Entity/Submit.php
@@ -21,6 +21,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * @ORM\Table(name="submit")
  * @ORM\Entity()
+ *
+ * @CustomAssert\NoSubmitDuplicate()
  */
 class Submit
 {

--- a/src/Event/Notification/SubmitCancelledEvent.php
+++ b/src/Event/Notification/SubmitCancelledEvent.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Starfleet Project.
+ *
+ * (c) Starfleet <msantostefano@jolicode.com>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace App\Event\Notification;
+
+use App\Entity\Conference;
+use App\Entity\Submit;
+use App\Entity\Talk;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class SubmitCancelledEvent extends Event
+{
+    private Talk $talk;
+    private Conference $conference;
+
+    public function __construct(
+        private Submit $submit,
+    ) {
+        $this->talk = $submit->getTalk();
+        $this->conference = $submit->getConference();
+    }
+
+    public function getSubmit(): Submit
+    {
+        return $this->submit;
+    }
+
+    public function getTalk(): Talk
+    {
+        return $this->talk;
+    }
+
+    public function getConference(): Conference
+    {
+        return $this->conference;
+    }
+}

--- a/src/Factory/Notifications/SubmitCancelledNotificationFactory.php
+++ b/src/Factory/Notifications/SubmitCancelledNotificationFactory.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Starfleet Project.
+ *
+ * (c) Starfleet <msantostefano@jolicode.com>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace App\Factory\Notifications;
+
+use App\Entity\Notifications\AbstractNotification;
+use App\Entity\Notifications\SubmitCancelledNotification;
+use App\Factory\SubmitFactory;
+use App\Factory\UserFactory;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+
+/**
+ * @method static                            SubmitCancelledNotification|Proxy createOne(array $attributes = [])
+ * @method static                            SubmitCancelledNotification[]|Proxy[] createMany(int $number, $attributes = [])
+ * @method static                            SubmitCancelledNotification|Proxy find($criteria)
+ * @method static                            SubmitCancelledNotification|Proxy findOrCreate(array $attributes)
+ * @method static                            SubmitCancelledNotification|Proxy first(string $sortedField = 'id')
+ * @method static                            SubmitCancelledNotification|Proxy last(string $sortedField = 'id')
+ * @method static                            SubmitCancelledNotification|Proxy random(array $attributes = [])
+ * @method static                            SubmitCancelledNotification|Proxy randomOrCreate(array $attributes = [])
+ * @method static                            SubmitCancelledNotification[]|Proxy[] all()
+ * @method static                            SubmitCancelledNotification[]|Proxy[] findBy(array $attributes)
+ * @method static                            SubmitCancelledNotification[]|Proxy[] randomSet(int $number, array $attributes = [])
+ * @method static                            SubmitCancelledNotification[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
+ * @method SubmitCancelledNotification|Proxy create($attributes = [])
+ */
+final class SubmitCancelledNotificationFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [
+            'emitter' => UserFactory::random(),
+            'trigger' => AbstractNotification::TRIGGER_SUBMIT_CANCELLED,
+        ];
+    }
+
+    protected function initialize(): self
+    {
+        return $this
+            ->instantiateWith(function (array $attributes) {
+                $submit = SubmitFactory::createOne([
+                    'users' => [
+                        $attributes['targetUser'],
+                        UserFactory::createOne(),
+                    ],
+                ]);
+
+                $notification = new SubmitCancelledNotification(
+                    $submit->getTalk(),
+                    $submit->getConference(),
+                    $attributes['emitter'],
+                    $attributes['targetUser'],
+                    $attributes['trigger']
+                );
+
+                return $notification;
+            })
+        ;
+    }
+
+    protected static function getClass(): string
+    {
+        return SubmitCancelledNotification::class;
+    }
+}

--- a/src/Validator/Constraints/NoSubmitDuplicate.php
+++ b/src/Validator/Constraints/NoSubmitDuplicate.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Starfleet Project.
+ *
+ * (c) Starfleet <msantostefano@jolicode.com>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace App\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/** @Annotation */
+class NoSubmitDuplicate extends Constraint
+{
+    public string $message = 'A submit for {{ conference }} is already registered with the same talk and the same users.';
+
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Validator/Constraints/NoSubmitDuplicateValidator.php
+++ b/src/Validator/Constraints/NoSubmitDuplicateValidator.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Starfleet Project.
+ *
+ * (c) Starfleet <msantostefano@jolicode.com>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace App\Validator\Constraints;
+
+use App\Entity\Submit;
+use App\Repository\SubmitRepository;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+class NoSubmitDuplicateValidator extends ConstraintValidator
+{
+    public function __construct(
+        private Security $security,
+        private SubmitRepository $submitRepository,
+    ) {
+    }
+
+    /**
+     * @param Submit|null       $submit
+     * @param NoSubmitDuplicate $constraint
+     */
+    public function validate($submit, Constraint $constraint): void
+    {
+        if (!$submit) {
+            return;
+        }
+
+        if (!$submit instanceof Submit) {
+            throw new UnexpectedValueException($submit, Submit::class);
+        }
+
+        $qb = $this->submitRepository->createQueryBuilder('s');
+        $existingSubmits = $qb
+            ->andWhere('s.conference = :conference')
+            ->andWhere('s.talk = :talk')
+            ->innerJoin('s.users', 'u')
+            ->andWhere('u.id IN (:users)')
+            ->setParameters([
+                'conference' => $submit->getConference(),
+                'talk' => $submit->getTalk(),
+                'users' => $submit->getUsers(),
+            ])
+            ->getQuery()
+            ->getResult()
+        ;
+
+        foreach ($existingSubmits as $existingSubmit) {
+            $submitUsers = $submit->getUsers()->toArray();
+            $existingSubmitUsers = $existingSubmit->getUsers()->toArray();
+            sort($submitUsers);
+            sort($existingSubmitUsers);
+
+            if ($submitUsers === $existingSubmitUsers) {
+                $this->context
+                    ->buildViolation($constraint->message)
+                    ->setParameter('{{ conference }}', $submit->getConference())
+                    ->addViolation()
+                ;
+
+                return;
+            }
+        }
+    }
+}

--- a/templates/user/notifications/submit_cancelled.html.twig
+++ b/templates/user/notifications/submit_cancelled.html.twig
@@ -1,0 +1,3 @@
+<strong>{{ notification.emitter }}</strong> <span class="color-cancel">cancelled</span> the submit for a talk you were giving together.
+The concerned talk was <a href="{{ path('show_talk', { id: notification.talk.id }) }}" class="text-primary">{{ notification.talk.title }}</a>,
+at <a href="{{ path('conferences_show', { slug: notification.conference.slug }) }}" class="text-primary">{{ notification.conference.name }}</a>

--- a/templates/user/submit/submit.html.twig
+++ b/templates/user/submit/submit.html.twig
@@ -237,6 +237,7 @@
                     class: 'row flex-column',
                 }
             }) }}
+                {{ form_errors(form) }}
                 {{ form_row(form.conference) }}
                 {{ form_row(form.talk) }}
                 {{ form_row(form.users) }}

--- a/templates/user/submit/submit_form.html.twig
+++ b/templates/user/submit/submit_form.html.twig
@@ -44,6 +44,7 @@
                 id: form.vars.id
             }
         }) }}
+            {{ form_errors(form) }}
             {{ form_row(form.conference) }}
             {{ form_row(form.talk) }}
             {{ form_row(form.users) }}

--- a/tests/Entity/Notifications/SubmitCancelledNotificationTest.php
+++ b/tests/Entity/Notifications/SubmitCancelledNotificationTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Starfleet Project.
+ *
+ * (c) Starfleet <msantostefano@jolicode.com>
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace App\Tests\Entity\Notifications;
+
+use App\Entity\Submit;
+use App\Factory\ConferenceFactory;
+use App\Factory\Notifications\SubmitCancelledNotificationFactory;
+use App\Factory\SubmitFactory;
+use App\Factory\TalkFactory;
+use App\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * @group notifications
+ */
+class SubmitCancelledNotificationTest extends WebTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testNotificationIsCreated()
+    {
+        $emitterUser = UserFactory::createOne();
+        $targetUser = UserFactory::createOne();
+        $submit = SubmitFactory::createOne([
+            'conference' => ConferenceFactory::createOne(),
+            'talk' => TalkFactory::createOne(),
+            'users' => [$emitterUser, $targetUser],
+            'status' => Submit::STATUS_PENDING,
+        ]);
+
+        $this->ensureKernelShutdown();
+        $client = $this->createClient();
+        $client->loginUser($emitterUser->object());
+        $client->request('GET', sprintf('/user/submits', $submit->getId()));
+
+        $client->submitForm('Cancel');
+        $targetUser->refresh();
+
+        self::assertCount(1, SubmitCancelledNotificationFactory::all());
+        self::assertCount(0, SubmitFactory::all());
+        self::assertSame($targetUser->object(), SubmitCancelledNotificationFactory::find(1)->getTargetUser());
+
+        $client->loginUser($targetUser->object());
+        $crawler = $client->request('GET', '/user/account');
+
+        $notificationsButton = $crawler->filter('div.notification-button');
+        self::assertSame('1 Notifications', $notificationsButton->text());
+    }
+}


### PR DESCRIPTION
Submits had several issues.

We didn't have duplicate protection for submits, so this adds one.

Notifications where not deleted on cascade, meaning that if someone cancelled a submit but someone else had a notification related to this submit, this submit FK would still be referenced in the notification.

Cancelling a submit did not trigger any event.