### PR TITLE
Fix submittedBy return type

### DIFF
--- a/src/Entity/Submit.php
+++ b/src/Entity/Submit.php
@@ -207,7 +207,7 @@ class Submit
         $this->statusChanged = false;
     }
 
-    public function getSubmittedBy(): User
+    public function getSubmittedBy(): ?User
     {
         return $this->submittedBy;
     }


### PR DESCRIPTION
The production database has null values for the `submittedBy` field, causing it to break (and there was a mismatch anyway).