### PR TITLE
Fix various blocking issues

### DIFF
--- a/config/packages/easy_admin/conference.yaml
+++ b/config/packages/easy_admin/conference.yaml
@@ -3,7 +3,7 @@ easy_admin:
         PassedConference:
             class: App\Entity\Conference
             controller: App\Controller\Admin\ConferenceController
-            disabled_actions: ['edit', 'delete']
+            disabled_actions: ['edit', 'delete', 'new']
             list:
                 title: 'Passed Conferences'
                 filters: ['name', 'city', 'country', 'startAt', 'tags', 'source']
@@ -69,7 +69,7 @@ easy_admin:
         ExcludedConference:
             class: App\Entity\Conference
             controller: App\Controller\Admin\ConferenceController
-            disabled_actions: ['delete']
+            disabled_actions: ['delete', 'new']
             list:
                 title: 'Excluded Conferences'
                 filters: ['name', 'city', 'country', 'startAt', 'tags', 'source']

--- a/config/packages/easy_admin/user.yaml
+++ b/config/packages/easy_admin/user.yaml
@@ -30,4 +30,3 @@ easy_admin:
                             multiple: true
                             choices:
                                 Admin: ROLE_ADMIN
-                                User: ROLE_USER

--- a/src/DataTransformer/ConferenceNameTransformer.php
+++ b/src/DataTransformer/ConferenceNameTransformer.php
@@ -38,12 +38,20 @@ class ConferenceNameTransformer implements DataTransformerInterface
             return null;
         }
 
-        $conference = $this->conferenceRepository->findOneBy(['name' => $conferenceName]);
+        $requestedConference = null;
 
-        if (null === $conference) {
+        foreach ($this->conferenceRepository->findBy(['name' => $conferenceName]) as $conference) {
+            $requestedConference = $requestedConference ?: $conference;
+
+            if ($requestedConference->getStartAt() < $conference->getStartAt()) {
+                $requestedConference = $conference;
+            }
+        }
+
+        if (!$requestedConference) {
             throw new TransformationFailedException(sprintf('The conference with name "%s" doesn\'t seem to exist.', $conferenceName));
         }
 
-        return $conference;
+        return $requestedConference;
     }
 }

--- a/src/Form/UserAccount/UserProfileType.php
+++ b/src/Form/UserAccount/UserProfileType.php
@@ -42,7 +42,7 @@ class UserProfileType extends AbstractType
                 'mapped' => false,
                 'required' => false,
             ])
-            ->add('password', PasswordType::class, [
+            ->add('newPassword', PasswordType::class, [
                 'required' => false,
                 'mapped' => false,
             ])

--- a/src/Repository/NotificationRepository.php
+++ b/src/Repository/NotificationRepository.php
@@ -29,10 +29,9 @@ class NotificationRepository extends ServiceEntityRepository
         parent::__construct($registry, AbstractNotification::class);
     }
 
-    /** @return array<AbstractNotification> */
-    public function markAllAsReadForUser(User $user): array
+    public function markAllAsReadForUser(User $user): void
     {
-        return $this->createQueryBuilder('n')
+        $this->createQueryBuilder('n')
             ->update()
             ->set('n.read', ':newRead')
             ->andWhere('n.targetUser = :user')

--- a/templates/user/notifications/new_submit.html.twig
+++ b/templates/user/notifications/new_submit.html.twig
@@ -1,3 +1,3 @@
 <strong>{{ notification.emitter }}</strong> <a href="{{ path(notification.submit.status ~ '_submits', { highlight: notification.submit.id }) }}" class="text-primary">submitted</a>
 a talk with you at <a href="{{ path('conferences_show', { slug: notification.submit.conference.slug }) }}" class="text-primary">{{ notification.submit.conference.name }}</a>.<br>
-You are to give the following talk : <a href="" class="text-primary">{{ notification.submit.talk }}</a>
+You are about to give the following talk : <a href="{{ path('show_talk', { id: notification.submit.talk.id }) }}" class="text-primary">{{ notification.submit.talk }}</a>

--- a/templates/user/profile/user_profile.html.twig
+++ b/templates/user/profile/user_profile.html.twig
@@ -22,7 +22,7 @@
                 {{ form_row(form.name) }}
                 {{ form_row(form.email) }}
                 {{ form_row(form.previousPassword) }}
-                {{ form_row(form.password) }}
+                {{ form_row(form.newPassword) }}
             </div>
 
             <div class="profile-form-block">

--- a/templates/user/submit/submit.html.twig
+++ b/templates/user/submit/submit.html.twig
@@ -19,8 +19,10 @@
 {% endblock %}
 
 {% block _submit_users_label %}
-    <label for="{{ full_name }}" class="d-block">Users</label>
-    {{ form_errors(form) }}
+    <label for="{{ full_name }}" class="d-block">
+        Users
+        {{ form_errors(form) }}
+    </label>
 {% endblock %}
 
 {% block _submit_users_widget %}

--- a/templates/user/submit/submit_form.html.twig
+++ b/templates/user/submit/submit_form.html.twig
@@ -19,7 +19,10 @@
 {% endblock %}
 
 {% block _submit_users_label %}
-    <label for="{{ full_name }}" class="d-block">Users</label>
+    <label for="{{ full_name }}" class="d-block">
+        Users
+        {{ form_errors(form) }}
+    </label>
 {% endblock %}
 
 {% block _submit_users_widget %}


### PR DESCRIPTION
There was some leftover bugs on the preprod that we needed to fix before production deployment.

Quick list :
     Admin 
- Remove the possibility to create a new past conference, which was not configured and breaking. Remove possibility to create a new Excluded Conference as well
- Admins could remove the User role of anyone, which would completely break their account.

User Account
- Fix issue when trying to submit or ask participation to a conference with multiple editions in the database. If you tried to submit a talk to the `foo` Conference, if a past `foo` Conference exists it will try to submit to this one and throw an error.
- Marking all notifications as read was not working
- We were missing form error for the user field in the participation form

I also reworded a few things here and there.