### PR TITLE
Fix notifications for tests and for prod

### DIFF
--- a/config/packages/easy_admin/submit.yaml
+++ b/config/packages/easy_admin/submit.yaml
@@ -3,8 +3,6 @@ easy_admin:
         Submit:
             class: App\Entity\Submit
             disabled_actions: ['show']
-            edit:
-                role: ROLE_SUBMIT_EDIT
             delete:
                 role: ROLE_SUBMIT_EDIT
             list:
@@ -16,8 +14,9 @@ easy_admin:
                     - { property: 'submittedBy', type: 'text' }
                     - { property: 'status', template: 'easy_admin/Submit/status.html.twig' }
                     - { property: 'users', type: 'array', label: 'Speakers' }
-            form:
-                fields:
+            edit:
+                role: ROLE_SUBMIT_EDIT
+                fields: &submitFields
                     - { type: 'group', columns: 6, icon: 'pencil', label: 'Submit' }
                     -   property: 'talk'
                         type: entity
@@ -41,3 +40,9 @@ easy_admin:
                         type_options:
                             multiple: true
                             class: App\Entity\User
+            new:
+                fields:
+                    <<: *submitFields
+                form_options: {
+                    validation_groups: ['Default', 'submit:create']
+                }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -75,3 +75,7 @@ services:
     App\Controller\UserAccount\ParticipationController:
         arguments:
             $workflow: '@state_machine.participation_request'
+
+    App\EventListener\SlackNotifierEventListener:
+        arguments:
+            $env: '%kernel.environment%'

--- a/src/Controller/UserAccount/SubmitController.php
+++ b/src/Controller/UserAccount/SubmitController.php
@@ -49,15 +49,13 @@ class SubmitController extends AbstractController
         $submit->addUser($user);
         $submit->setSubmittedBy($user);
         $form = $this->createForm(SubmitType::class, $submit, [
-            'validation_groups' => ['Default', 'user_account'],
+            'validation_groups' => ['Default', 'user_account', 'submit:create'],
         ]);
 
         if ($form->handleRequest($request)->isSubmitted() && $form->isValid()) {
             $this->em->persist($submit);
 
-            if (\count($submit->getUsers()) > 1) {
-                $this->eventDispatcher->dispatch(new NewSubmitEvent($submit));
-            }
+            $this->eventDispatcher->dispatch(new NewSubmitEvent($submit));
 
             $this->em->flush();
             $this->addFlash('info', 'The submit has been saved.');
@@ -180,9 +178,7 @@ class SubmitController extends AbstractController
         if ($form->handleRequest($request)->isSubmitted() && $form->isValid()) {
             $this->em->persist($submit);
 
-            if (\count($submit->getUsers()) > 1) {
-                $this->eventDispatcher->dispatch(new NewSubmitEvent($submit));
-            }
+            $this->eventDispatcher->dispatch(new NewSubmitEvent($submit));
 
             $this->em->flush();
             $this->addFlash('info', 'Your talk has been submitted.');

--- a/src/Entity/Submit.php
+++ b/src/Entity/Submit.php
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @ORM\Table(name="submit")
  * @ORM\Entity()
  *
- * @CustomAssert\NoSubmitDuplicate()
+ * @CustomAssert\NoSubmitDuplicate(groups={"submit:create"})
  */
 class Submit
 {

--- a/src/EventListener/Notification/NotificationsEventListener.php
+++ b/src/EventListener/Notification/NotificationsEventListener.php
@@ -18,12 +18,14 @@ use App\Entity\Notifications\ParticipationStatusChangedNotification;
 use App\Entity\Notifications\SubmitCancelledNotification;
 use App\Entity\Notifications\SubmitStatusChangedNotification;
 use App\Entity\User;
+use App\Event\NewTalkSubmittedEvent;
 use App\Event\Notification\NewFeaturedConferenceEvent;
 use App\Event\Notification\NewSubmitEvent;
 use App\Event\Notification\ParticipationStatusChangedEvent;
 use App\Event\Notification\SubmitCancelledEvent;
 use App\Event\Notification\SubmitStatusChangedEvent;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Security;
 
@@ -32,6 +34,7 @@ class NotificationsEventListener implements EventSubscriberInterface
     public function __construct(
         private Security $security,
         private EntityManagerInterface $em,
+        private EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -66,6 +69,8 @@ class NotificationsEventListener implements EventSubscriberInterface
 
             $this->em->persist($notification);
         }
+
+        $this->eventDispatcher->dispatch(new NewTalkSubmittedEvent($event->getSubmit()->getTalk(), [$event->getSubmit()]));
     }
 
     public function onSubmitStatusChanged(SubmitStatusChangedEvent $event): void

--- a/src/EventListener/SlackNotifierEventListener.php
+++ b/src/EventListener/SlackNotifierEventListener.php
@@ -20,12 +20,15 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class SlackNotifierEventListener implements EventSubscriberInterface
 {
-    private bool $disabled;
+    private bool $disabled = false;
 
     public function __construct(
         private SlackNotifier $slackNotifier,
+        private string $env,
     ) {
-        $this->disabled = false;
+        if ('test' === $env) {
+            $this->disable();
+        }
     }
 
     /**


### PR DESCRIPTION
Notifications were having issues for both tests and prod :

- For tests we were trying to send requests to Slack, leading to 404 resulting in bugs.
- For prod a validator was causing havoc if used while editing an entity. Also, in the user account, we didn't send a notification if only one user was submitting a talk.

@welcoMattic I suggest you rebase your PR on this one, it will probably not fix all the issues with the tests but it might help fixing some :) (in my case it was causing 2 failures).