### PR TITLE
Fix wrong CSS and misplaced no submits block

### DIFF
--- a/templates/user/participation/participation.html.twig
+++ b/templates/user/participation/participation.html.twig
@@ -19,17 +19,6 @@
 
 {% block content %}
     <aside class="col-6">
-
-        {% if not futureParticipations|length and
-            not pendingParticipations|length and
-            not rejectedParticipations|length and
-            not pastParticipations|length
-        %}
-            <div class="d-flex justify-content-center align-items-center h-100">
-                <em>You have no participation at a conference yet. Maybe soon ?</em>
-            </div>
-        {% endif %}
-
         {% if futureParticipations|length %}
             <div class="mb-5" id="future-participations-block">
                 <h2 class="mx-0 mb-5">Conferences you will attend soon</h2>
@@ -123,6 +112,17 @@
                 {% if pastParticipations|length > 3 %}
                     <a href="{{ path('past_participations') }}"><span class="text-primary">...Show more</span></a>
                 {% endif %}
+            </div>
+        {% endif %}
+
+        {% if
+            not futureParticipations|length and
+            not pendingParticipations|length and
+            not rejectedParticipations|length and
+            not pastParticipations|length
+        %}
+            <div class="mb-5 mt-5">
+                <em>You have no participation at a conference yet. Maybe soon ?</em>
             </div>
         {% endif %}
     </aside>

--- a/templates/user/submit/submit.html.twig
+++ b/templates/user/submit/submit.html.twig
@@ -95,10 +95,6 @@
                     <a href="{{ path('pending_submits') }}"><span class="text-primary">...Show more</span></a>
                 {% endif %}
             </div>
-        {% else %}
-            <div class="d-flex justify-content-center align-items-center h-100">
-                <em>You don't have any submit to show yet. Maybe soon ?</em>
-            </div>
         {% endif %}
 
         {% if futureSubmits|length %}
@@ -225,6 +221,17 @@
                 {% if rejectedSubmits|length > 3 %}
                     <a href="{{ path('rejected_submits') }}"><span class="text-primary">...Show more</span></a>
                 {% endif %}
+            </div>
+        {% endif %}
+
+        {% if
+            not pendingSubmits|length and
+            not futureSubmits|length and
+            not doneSubmits|length and
+            not rejectedSubmits|length
+        %}
+            <div class="mb-5 mt-5">
+                <em>You don't have any submit to show yet. Maybe soon ?</em>
             </div>
         {% endif %}
     </aside>

--- a/templates/user/talk/talk.html.twig
+++ b/templates/user/talk/talk.html.twig
@@ -66,7 +66,7 @@
                 {% endif %}
             </div>
         {% else %}
-            <div class="d-flex justify-content-center align-items-center h-100">
+            <div class="mt-5 mb-5">
                 <em>You don't have any talk to show yet. Maybe soon ?</em>
             </div>
         {% endif %}


### PR DESCRIPTION
fix #256 

The else block we wanted to show if there was no submits/participations was at the wrong place and the CSS was causing issues for almost no benefits so I just removed it. 