### PR TITLE
Fix add participation validation

### DIFF
--- a/src/Entity/Participation.php
+++ b/src/Entity/Participation.php
@@ -9,6 +9,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Entity()
+ *
+ * @CustomAssert\NoParticipationDuplicate()
  */
 class Participation
 {
@@ -38,8 +40,6 @@ class Participation
      * @ORM\ManyToOne(targetEntity="App\Entity\Conference", inversedBy="participations", cascade={"persist"})
      *
      * @ORM\JoinColumn(nullable=false)
-     *
-     * @CustomAssert\NoParticipationDuplicate()
      *
      * @CustomAssert\NotEndedConference()
      */

--- a/src/Validator/Constraints/NoParticipationDuplicate.php
+++ b/src/Validator/Constraints/NoParticipationDuplicate.php
@@ -8,4 +8,9 @@ use Symfony\Component\Validator\Constraint;
 class NoParticipationDuplicate extends Constraint
 {
     public string $message = 'A participation at this conference is already registered for {{ user_name }}.';
+
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
 }

--- a/src/Validator/Constraints/NoParticipationDuplicateValidator.php
+++ b/src/Validator/Constraints/NoParticipationDuplicateValidator.php
@@ -2,10 +2,8 @@
 
 namespace App\Validator\Constraints;
 
-use App\Entity\Conference;
-use App\Entity\User;
+use App\Entity\Participation;
 use App\Repository\ParticipationRepository;
-use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
@@ -13,36 +11,33 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
 class NoParticipationDuplicateValidator extends ConstraintValidator
 {
     public function __construct(
-        private Security $security,
         private ParticipationRepository $participationRepository,
     ) {
     }
 
     /**
-     * @param Conference|null          $conference
+     * @param Participation|null       $participation
      * @param NoParticipationDuplicate $constraint
      */
-    public function validate($conference, Constraint $constraint): void
+    public function validate($participation, Constraint $constraint): void
     {
-        if (!$conference) {
+        if (!$participation) {
             return;
         }
 
-        if (!$conference instanceof Conference) {
-            throw new UnexpectedValueException($conference, Conference::class);
+        if (!$participation instanceof Participation) {
+            throw new UnexpectedValueException($participation, Participation::class);
         }
 
-        /** @var User $user */
-        $user = $this->security->getUser();
         $existingParticipation = $this->participationRepository->findOneBy([
-            'participant' => $user,
-            'conference' => $conference,
+            'participant' => $participation->getParticipant(),
+            'conference' => $participation->getConference(),
         ]);
 
         if ($existingParticipation) {
             $this->context
                 ->buildViolation($constraint->message)
-                ->setParameter('{{ user_name }}', $user->getName())
+                ->setParameter('{{ user_name }}', $participation->getParticipant()->getName())
                 ->addViolation()
             ;
         }


### PR DESCRIPTION
Previously, a logged-in user can't add a participation for another user (the duplication validation was triggered with the current logged-in user). Now the validation is made with the selected user in Participation add form.