### PR TITLE
fix: limit conferences selects to future conferences

### DIFF
--- a/config/packages/easy_admin/participation.yaml
+++ b/config/packages/easy_admin/participation.yaml
@@ -21,7 +21,7 @@ easy_admin:
                 item_permission: ['ROLE_PARTICIPATION_MANAGEMENT']
                 fields:
                     - { type: 'group', columns: 6, icon: 'id-badge', label: 'Participation' }
-                    - { property: 'conference', type: 'App\Form\EasyAdmin\ParticipationConferencesType', type_options: { attr: { data-widget: 'select2' } } }
+                    - { property: 'conference', type: 'App\Form\EasyAdmin\FutureConferencesType', type_options: { attr: { data-widget: 'select2' } } }
                     - { property: 'participant' }
                     - { property: 'asSpeaker' }
                     - property: 'transportStatus'

--- a/config/packages/easy_admin/talk.yaml
+++ b/config/packages/easy_admin/talk.yaml
@@ -31,6 +31,6 @@ easy_admin:
                 fields:
                     <<: *talkFields
                     4: { type: 'group', columns: 6, icon: 'send', label: 'Publication' }
-                    5: { property: 'conferences', type: 'easyadmin_autocomplete', type_options: { mapped: false, class: App\Entity\Conference, multiple: true } }
+                    5: { property: 'conference', type: 'App\Form\EasyAdmin\FutureConferencesType', type_options: { mapped: false, class: App\Entity\Conference, multiple: true, attr: { data-widget: 'select2' } } }
                     6: { property: authors, type: App\Form\EasyAdmin\TalkUserType, type_options: { mapped: false, required: true } }
 

--- a/src/Form/EasyAdmin/FutureConferencesType.php
+++ b/src/Form/EasyAdmin/FutureConferencesType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class ParticipationConferencesType extends AbstractType
+class FutureConferencesType extends AbstractType
 {
     public function __construct(
         private ConferenceRepository $conferenceRepository,

--- a/src/Form/EasyAdmin/TalkSubmitType.php
+++ b/src/Form/EasyAdmin/TalkSubmitType.php
@@ -15,6 +15,7 @@ use App\Entity\Conference;
 use App\Entity\Submit;
 use App\Entity\Talk;
 use App\Entity\User;
+use App\Repository\ConferenceRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminAutocompleteType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -29,6 +30,7 @@ class TalkSubmitType extends AbstractType
 {
     public function __construct(
         private RequestStack $requestStack,
+        private ConferenceRepository $conferenceRepository,
     ) {
     }
 
@@ -40,6 +42,7 @@ class TalkSubmitType extends AbstractType
             ])
             ->add('conference', EasyAdminAutocompleteType::class, [
                 'class' => Conference::class,
+                'query_builder' => $this->conferenceRepository->getFutureConferencesQueryBuilder(),
             ])
             ->add('status', ChoiceType::class, [
                 'choices' => array_flip(Submit::STATUS_EMOJIS),


### PR DESCRIPTION
Talk creation and submit creation forms has both conference select input which is filled with all conferences, not only future *and* not excluded ones. This PR fixes it.